### PR TITLE
[Feat] husky로 테스트 자동 실행 설정

### DIFF
--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,9 +1,42 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/husky.sh"
+#!/bin/sh
 
 echo "\033[33m🏃‍♂️ Running pre-commit hooks...\033[0m"
 
+# lint-staged 실행
 echo "\033[34m📝 Running lint-staged...\033[0m"
-pnpm lint-staged
+pnpm lint-staged || {
+    echo "\033[31m❌ Lint-staged failed. Please fix the errors and try again.\033[0m"
+    exit 1
+}
 
-echo "\033[32m✅ Pre-commit checks passed!\033[0m"
+#변경된 파일 워크스페이스 찾기
+CHANGED_FILES=$(git diff --cached --name-only)
+
+# API서버 테스트
+if echo "$CHANGED_FILES" | grep -q "^apps/api/"; then
+    echo "\033[34m🧪 Running API tests...\033[0m"
+    pnpm test:api || {
+        echo "\033[31m❌ API tests failed. Please fix the failing tests and try again.\033[0m"
+        exit 1
+    }
+fi
+
+# Chat서버 테스트
+if echo "$CHANGED_FILES" | grep -q "^apps/chat/"; then
+    echo "\033[34m🧪 Running Chat tests...\033[0m"
+    pnpm test:chat || {
+        echo "\033[31m❌ Chat tests failed. Please fix the failing tests and try again.\033[0m"
+        exit 1
+    }
+fi
+
+# Media서버 테스트
+if echo "$CHANGED_FILES" | grep -q "^apps/media/"; then
+    echo "\033[34m🧪 Running Media tests...\033[0m"
+    pnpm test:media || {
+        echo "\033[31m❌ Media tests failed. Please fix the failing tests and try again.\033[0m"
+        exit 1
+    }
+fi
+
+echo "\033[32m✅ All pre-commit checks passed!\033[0m"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api",
+  "name": "@web20-camon/api",
   "version": "0.0.1",
   "description": "",
   "author": "",
@@ -13,11 +13,8 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test": "jest --config ./test/config/jest.config.json",
+    "test:e2e": "jest --config ./test/config/jest-e2e.config.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/apps/api/test/config/jest-e2e.config.json
+++ b/apps/api/test/config/jest-e2e.config.json
@@ -1,0 +1,30 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "../../",
+  "testEnvironment": "node",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "testMatch": [
+    "<rootDir>/test/**/*.e2e-spec.ts"
+  ],
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
+  },
+  "collectCoverageFrom": [
+    "test/**/*.(t|j)s"
+  ],
+  "coverageDirectory": "./coverage/e2e",
+  "verbose": true,
+  "testPathIgnorePatterns": [
+    "/node_modules/",
+    "/dist/"
+  ],
+  "roots": [
+    "<rootDir>/test/"
+  ],
+  "moduleDirectories": [
+    "node_modules",
+    "src"
+  ]
+}

--- a/apps/api/test/config/jest.config.json
+++ b/apps/api/test/config/jest.config.json
@@ -1,0 +1,30 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "../../",
+  "testEnvironment": "node",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "testMatch": [
+    "<rootDir>/test/**/*.spec.ts"
+  ],
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
+  },
+  "collectCoverageFrom": [
+    "test/**/*.(t|j)s"
+  ],
+  "coverageDirectory": "./coverage/unit",
+  "verbose": true,
+  "testPathIgnorePatterns": [
+    "/node_modules/",
+    "/dist/"
+  ],
+  "roots": [
+    "<rootDir>/test/"
+  ],
+  "moduleDirectories": [
+    "node_modules",
+    "src"
+  ]
+}

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
-}

--- a/apps/api/test/unit/app.controller.spec.ts
+++ b/apps/api/test/unit/app.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { AppController } from '../../src/app.controller';
+import { AppService } from '../../src/app.service';
 
 describe('AppController', () => {
   let appController: AppController;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "pnpm -r test",
+    "test:api": "pnpm --filter @web20-camon/api test && pnpm --filter @web20-camon/api test:e2e",
+    "test:chat": "pnpm --filter @web20-camon/chat test",
+    "test:media": "pnpm --filter @web20-camon/media test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
>이슈번호
> #76

## ✨ 구현 기능 명세
### 모노레포 jest 세팅

**api서버 config 파일 수정**

- test 파일을 unit 테스트와 e2e 테스트 모두 test 폴더 내에서 관리하기로 하였으므로 test 폴더 내에 config 폴더를 생성하여 unit, e2e config 파일을 생성해 주었습니다.
- 각 config파일은 jest에서 어떤 파일을 test파일로 감지하여 실행할지를 나타내고 있습니다.
- Unit과 e2e를 합쳐 한번에 모든 테스트가 돌아가도록 구현할 수 있었는데 혹시나 테스트를 따로 해야할 일이 생길수도 있다는 생각에 따로 생성 해주었습니다.

**api서버 → package.json**

```json
{
  "name": "@web20-camon/api",
  ...
  "scripts": {
    ...
    "test": "jest --config ./test/config/jest.config.json",
    "test:e2e": "jest --config ./test/config/jest-e2e.config.json"
  },
  ...
}

```

- 각 서버의 package.json 수정이 필요합니다. 그 중 api 서버의 수정 내용입니다.
- 가장 주의해야 할 점은 package.json의 name을 root package.json에서 명시해준 name으로 변경해주어야 한다는 것입니다. 그래야 모노레포가 인식을 하더라구요.
- nest 에서 기본적으로 제공하는 test script는 삭제해주고 unit test를 위한 스크립트와 e2e 테스트를 위한 스크립트를 변경해 주었습니다.
- 앞서 작성한 config 파일을 jest —config 옵션으로 명시하여 실행시키면서, 각각 알맞게 테스트 파일이 실행되도록 스크립트를 작성했습니다.

### Husky 테스트 스크립트 작성

**root → package.json**

```json
"scripts": {
  ...
  "test:api": "pnpm --filter @web20-camon/api test && pnpm --filter @web20-camon/api test:e2e",
  "test:chat": "pnpm --filter @web20-camon/chat test",
  "test:media": "pnpm --filter @web20-camon/media test"
},
```

- 모노레포의 scripts에 위와 같은 스크립트를 추가해주었습니다.
- 각 api, chat, media 서버 마다 테스트 스크립트를 만들고 —filter 옵션으로 해당 워크스페이스의 파일만 test 할 수 있도록 하였습니다.
- api서버는 unit test와 e2e test가 모두 실행될 수 있도록 작성하였습니다.
- chat과 media 서버는 어떻게 테스트가 이루어질지 몰라 일단 기본으로 두었습니다.

**.husky → pre-commit**

```bash
#변경된 파일 워크스페이스 찾기
CHANGED_FILES=$(git diff --cached --name-only)

# API서버 테스트
if echo "$CHANGED_FILES" | grep -q "^apps/api/"; then
    echo "\033[34m🧪 Running API tests...\033[0m"
    pnpm test:api || {
        echo "\033[31m❌ API tests failed. Please fix the failing tests and try again.\033[0m"
        exit 1
    }
fi

# Chat서버 테스트
if echo "$CHANGED_FILES" | grep -q "^apps/chat/"; then
    echo "\033[34m🧪 Running Chat tests...\033[0m"
    pnpm test:chat || {
        echo "\033[31m❌ Chat tests failed. Please fix the failing tests and try again.\033[0m"
        exit 1
    }
fi

# Media서버 테스트
if echo "$CHANGED_FILES" | grep -q "^apps/media/"; then
    echo "\033[34m🧪 Running Media tests...\033[0m"
    pnpm test:media || {
        echo "\033[31m❌ Media tests failed. Please fix the failing tests and try again.\033[0m"
        exit 1
    }
fi
```

- 기존의 husky 스크립트에 위와 같은 코드를 추가해주었습니다.
- git diff 명령어로 코드가 변경된 워크스페이스들을 찾고, 이에 해당한다면 각 서버의 test 명령어를 실행하도록 구현하였습니다.
- 만약 test에 실패할 경우 exit1로 commit이 올라가지 않도록 했습니다.

### 결과

**커밋 후 테스트 성공 시**
![스크린샷 2024-11-07 오전 2 04 15](https://github.com/user-attachments/assets/c82f8aeb-b60d-4958-b8d5-ee0fe2a0370d)

**커밋 후 테스트 실패시**
![스크린샷 2024-11-07 오전 2 04 46](https://github.com/user-attachments/assets/9d475dcb-da9e-460e-9774-78b1658d3652)
