### PR TITLE
[Ci] 프론트 배포 스크립트 작성

### DIFF
--- a/.github/workflows/front-deploy.yml
+++ b/.github/workflows/front-deploy.yml
@@ -3,9 +3,8 @@ on:
   push:
     branches:
       - develop
-      - Ci/83
-#    paths:
-#      - 'apps/client/**'
+    paths:
+      - 'apps/client/**'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -34,23 +33,28 @@ jobs:
         working-directory: apps/client
         run: pnpm build
 
-  deploy-main:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      # GitHub 레포지토리 체크아웃
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Verify build output
+        run: ls -la apps/client/dist
 
-      # SSH Key 설정
+      - name: Upload files to server
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_SERVER_KEY }}
+          source: "apps/client/dist/*"
+          target: "/home/ubuntu/myapp"
+
       - name: Deploy to Server
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v0.1.6
         with:
           host: ${{ secrets.SERVER_IP }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SSH_SERVER_KEY }}
           script: |
-            # 배포 디렉토리 생성
-            mkdir -p /var/www/myapp
-            # 빌드된 파일을 서버로 전송
-            rsync -avz --delete apps/client/dist/ /var/www/myapp
+            echo "${{ secrets.SERVER_USER_PASSWORD }}" | sudo -S mkdir -p /var/www/myapp
+            echo "${{ secrets.SERVER_USER_PASSWORD }}" | sudo -S cp -r /home/ubuntu/myapp/* /var/www/myapp
+            echo "${{ secrets.SERVER_USER_PASSWORD }}" | sudo -S chown -R www-data:www-data /var/www/myapp
+            echo "${{ secrets.SERVER_USER_PASSWORD }}" | sudo -S rm -rf /home/ubuntu/myapp
+          
+      

--- a/.github/workflows/front-deploy.yml
+++ b/.github/workflows/front-deploy.yml
@@ -1,0 +1,56 @@
+name: Front Ci/Cd
+on:
+  push:
+    branches:
+      - develop
+      - Ci/83
+#    paths:
+#      - 'apps/client/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # GitHub 레포지토리 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Node.js 환경 설정
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '21'
+
+      # pnpm 설치
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      # 의존성 설치
+      - name: Install dependencies
+        working-directory: apps/client
+        run: pnpm install
+
+      # 빌드 실행
+      - name: Build front-end
+        working-directory: apps/client
+        run: pnpm build
+
+  deploy-main:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # GitHub 레포지토리 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # SSH Key 설정
+      - name: Deploy to Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_SERVER_KEY }}
+          script: |
+            # 배포 디렉토리 생성
+            mkdir -p /var/www/myapp
+            # 빌드된 파일을 서버로 전송
+            rsync -avz --delete apps/client/dist/ /var/www/myapp


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #83

## ✨ 구현 기능 명세
- /apps/client에 변경 사항이 감지되면 클라이언트 배포 스크립트가 동작하게 설정
- pnpm으로 build 후 build된 파일을 서버에 배포
## 🎁 PR Point

## 😭 어려웠던 점
- sudo 명령어를 사용할 때 비밀번호를 요구
- 해결하려고 사용자에게 sudo를 비밀번호 없이 사용하게 만드려고 했는데 실패했습니다