### PR TITLE
[Fix] react Router v7 관련 옵션 추가

### DIFF
--- a/apps/client/src/Router.tsx
+++ b/apps/client/src/Router.tsx
@@ -5,29 +5,43 @@ import Profile from '@pages/Profile';
 import Live from '@pages/Live';
 import Broadcast from './pages/Broadcast';
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <App />,
-    children: [
-      {
-        path: '',
-        element: <Home />,
-      },
-      {
-        path: 'profile',
-        element: <Profile />,
-      },
-      {
-        path: 'live',
-        element: <Live />,
-      },
-    ],
+const routerOptions = {
+  future: {
+    v7_startTransition: true,
+    v7_relativeSplatPath: true,
+    v7_fetcherPersist: true,
+    v7_normalizeFormMethod: true,
+    v7_partialHydration: true,
+    v7_skipActionErrorRevalidation: true,
   },
-  {
-    path: 'broadcast',
-    element: <Broadcast />,
-  },
-]);
+};
+
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <App />,
+      children: [
+        {
+          path: '',
+          element: <Home />,
+        },
+        {
+          path: 'profile',
+          element: <Profile />,
+        },
+        {
+          path: 'live',
+          element: <Live />,
+        },
+      ],
+    },
+    {
+      path: 'broadcast',
+      element: <Broadcast />,
+    },
+  ],
+  routerOptions,
+);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #120 

## ✨ 구현 기능 명세

- app/client/src/Router.tsx에 React Router v7 관련 옵션 추가

```javascript
const routerOptions = {
  future: {
    v7_startTransition: true,
    v7_relativeSplatPath: true,
    v7_fetcherPersist: true,
    v7_normalizeFormMethod: true,
    v7_partialHydration: true,
    v7_skipActionErrorRevalidation: true,
  },
};

const router = createBrowserRouter(
  [
    // 라우팅 설정
  ],
  routerOptions,
);
```

## 🎁 PR Point

## 😭 어려웠던 점

미디어 스트림을 못 갖고 오는 건 이게 문제가 아닐 것 같긴 한데, 일단 경고 메시지는 안 뜨게 하기 위해 React Router v7 관련 옵션을 넣었다.

- [참고 자료](https://reactrouter.com/en/main/upgrading/future)
