### PR TITLE
[Feat] 방 생성 요청 커스텀 훅 구현

### DIFF
--- a/apps/client/src/hooks/useMediasoupRoom.ts
+++ b/apps/client/src/hooks/useMediasoupRoom.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { Socket } from 'socket.io-client';
+
+interface createRoomResponse {
+  roomId: string;
+}
+
+export const useMediasoupRoom = (socket: Socket) => {
+  const [roomId, setRoomId] = useState<string>('');
+  const [roomError, setRoomError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    try {
+      socket.emit('createRoom', (response: createRoomResponse) => {
+        setRoomId(response.roomId);
+      });
+    } catch (err) {
+      setRoomError(err instanceof Error ? err : new Error('Room 생성 실패'));
+    }
+  }, [socket]);
+
+  return {
+    roomId,
+    roomError,
+  };
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #108 

## ✨ 구현 기능 명세

- `useMediasoupRoom`  구현

## 🎁 PR Point

- `useMediasoupRoom` 동작

  - Wensocket으로 `createRoom` 요청을 보냄
  - roomId를 받음

## 😭 어려웠던 점
