### PR TITLE
[Fix] 프론트엔드 빌드 실패 원인 해결

### DIFF
--- a/apps/client/src/components/LivePlayer.tsx
+++ b/apps/client/src/components/LivePlayer.tsx
@@ -30,9 +30,7 @@ function LivePlayer() {
   };
 
   const handleExpand = () => {
-    if (videoRef.current.requestFullscreen) {
-      videoRef.current.requestFullscreen();
-    }
+    videoRef.current?.requestFullscreen?.();
   };
 
   return (

--- a/apps/client/src/components/common/Header.tsx
+++ b/apps/client/src/components/common/Header.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { Button } from '../ui/button';
 import { useNavigate } from 'react-router-dom';
+import { cn } from '@/lib/utils';
 
 function Header() {
   const [isLogIn, setIsLogIn] = useState(true);
@@ -66,7 +67,9 @@ function Header() {
       {isLogIn ? (
         <div className="flex gap-2">
           <Button
-            className={!isCheckedIn && 'bg-surface-brand-default hover:bg-surface-brand-alt'}
+            className={cn({
+              'bg-surface-brand-default hover:bg-surface-brand-alt': !isCheckedIn,
+            })}
             onClick={handleCheckInClick}
           >
             체크인

--- a/apps/client/src/components/ui/button.tsx
+++ b/apps/client/src/components/ui/button.tsx
@@ -39,11 +39,12 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, Var
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, textSize, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+    return <Comp className={cn(buttonVariants({ variant, size, textSize, className }))} ref={ref} {...props} />;
   },
 );
 Button.displayName = 'Button';
 
-export { Button, buttonVariants, ButtonProps };
+export { Button, type ButtonProps };
+export { buttonVariants };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #129 

## ✨ 구현 기능 명세

- LivePlayer.tsx에서 videoRef.current가 null일 수 있는 경우 처리
- Header.tsx에서 className 조건문 수정
- shadcn/ui 버튼 수정

## 🎁 PR Point

### LivePlayer.tsx

```typescript
const handleExpand = () => {
  if(videoRef.current.requestFullscreen){
    videoRef.current.requestFullscreen();
  }
};
```

여기서 `(videoRef.current`이 `null`일 수도 있다는 경고 발생해서 아래와 같이 수정했다.

```typescript
const handleExpand = () => {
  videoRef.current?.requestFullscreen?.();
};
```

여기서 `requestFullscreen`인지도 확인하는 이유는 브라우저 호환성 때문이다. 일부 오래된 브라우저에서는 브라우저별 접두사가 붙은 다른 메서드 이름을 사용한다. 그래서 확인하는 과정이 들어간다. 그렇지만 최신 브라우저들은 대부분 표준 requestFullscreen을 지원한다.

### Header.tsx

```html
<Button
  className={!isCheckedIn && 'bg-surface-brand-default hover:bg-surface-brand-alt' }
  onClick={handleCheckInClick}
>
  체크인
</Button>
```

`!isCheckedIn`이 false일 때 undefined가 반환되어 타입 에러가 발생했다. `&&`은 처음으로 만나는 falsy한 피연산자의 값을 반환하기 때문에 이런 오류가 발생한 것 같다. [참고 자료: 논리적 AND (&&) - MDN](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/Logical_AND)

그래서 삼항연산자로 변경해서 사용할까 하다가 `cn`을 사용했다. `cn`을 사용하면 조건에 따라 보이는 CSS를 다르게 하는 것을 좀 더 쉽게 할 수 있다. [cn 참고 자료](https://tigerabrodi.blog/the-story-behind-tailwinds-cn-function)

```html
<Button
  className={cn({
    'bg-surface-brand-default hover:bg-surface-brand-alt': !isCheckedIn,
  })}
  onClick={handleCheckInClick}
  >
  체크인
  </Button>
```

### shadcn/ui 버튼 수정

Typscript에서 `isolatedModules: true`일 때는 타입과 값을 명확히 구분해야 한다. 나 같은 경우는 export를 할 때 buttonProps에 타입이라고 명시해주지 않아서 그랬던 것 같다. 

```typescript
export { Button, type ButtonProps, buttonVariants }
```

이렇게 나눠줘야 한다.

## 😭 어려웠던 점
