### PR TITLE
[Feat] 방송 생성 및 시청자 수 증감 서비스 로직 구현

### DIFF
--- a/apps/media/src/broadcast/broadcast.entity.ts
+++ b/apps/media/src/broadcast/broadcast.entity.ts
@@ -1,0 +1,28 @@
+import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
+import { Member } from '../member/member.entity';
+
+@Entity()
+export class Broadcast {
+  @PrimaryColumn()
+  id: string;
+
+  @Column({ length: 255 })
+  title: string;
+
+  @Column({ type: 'text', nullable: true })
+  thumbnail: string;
+
+  @Column({ default: 0 })
+  viewers: number;
+
+  // startTime과 createdAt이 시간과 날짜를 분리해서 나타내는 거라면, 하나의 변수로 합치는 건 어떨까?
+  @Column()
+  startTime: Date;
+
+  @CreateDateColumn({ name: 'createdAt' })
+  createdAt: Date;
+
+  @OneToOne(() => Member)
+  @JoinColumn({ name: 'memberId' })
+  member: Member;
+}

--- a/apps/media/src/broadcast/broadcast.module.ts
+++ b/apps/media/src/broadcast/broadcast.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Broadcast } from './broadcast.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Broadcast])],
+  providers: [],
+})
+export class BroadcastModule {}

--- a/apps/media/src/broadcast/broadcast.module.ts
+++ b/apps/media/src/broadcast/broadcast.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Broadcast } from './broadcast.entity';
+import { BroadcastService } from './broadcast.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Broadcast])],
-  providers: [],
+  providers: [BroadcastService],
 })
 export class BroadcastModule {}

--- a/apps/media/src/broadcast/broadcast.service.ts
+++ b/apps/media/src/broadcast/broadcast.service.ts
@@ -3,6 +3,8 @@ import { Broadcast } from './broadcast.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateBroadcastDto } from './dto/createBroadcast.dto';
+import { CustomException } from 'src/common/responses/exceptions/custom.exception';
+import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
 
 @Injectable()
 export class BroadcastService {
@@ -26,6 +28,45 @@ export class BroadcastService {
       startTime: new Date(),
       member: null, // 현재 방송자에 대한 부분은 논의 후 로직 적용
     });
+
+    return await this.broadcastRepository.save(broadcast);
+  }
+
+  /**
+   * 방송의 시청자 수를 증가시킵니다.
+   * @param broadcastId 방송 UUID
+   * @returns 업데이트된 방송 정보
+   */
+  async incrementViewers(broadcastId: string): Promise<Broadcast> {
+    const broadcast = await this.broadcastRepository.findOne({
+      where: { id: broadcastId },
+    });
+
+    if (!broadcast) {
+      throw new CustomException(ErrorStatus.BROADCAST_NOT_FOUND);
+    }
+
+    broadcast.viewers += 1;
+    return await this.broadcastRepository.save(broadcast);
+  }
+
+  /**
+   * 방송의 시청자 수를 감소시킵니다.
+   * @param broadcastId 방송 UUID
+   * @returns 업데이트된 방송 정보
+   */
+  async decrementViewers(broadcastId: string): Promise<Broadcast> {
+    const broadcast = await this.broadcastRepository.findOne({
+      where: { id: broadcastId },
+    });
+
+    if (!broadcast) {
+      throw new CustomException(ErrorStatus.BROADCAST_NOT_FOUND);
+    }
+
+    if (broadcast.viewers > 0) {
+      broadcast.viewers -= 1;
+    }
 
     return await this.broadcastRepository.save(broadcast);
   }

--- a/apps/media/src/broadcast/broadcast.service.ts
+++ b/apps/media/src/broadcast/broadcast.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { Broadcast } from './broadcast.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateBroadcastDto } from './dto/createBroadcast.dto';
+
+@Injectable()
+export class BroadcastService {
+  constructor(
+    @InjectRepository(Broadcast)
+    private readonly broadcastRepository: Repository<Broadcast>,
+  ) {}
+
+  /**
+   * 새로운 방송을 생성합니다.
+   * @param createBroadcastDto 방송 생성에 필요한 정보
+   * @returns 생성된 방송 정보
+   */
+  async createBroadcast(createBroadcastDto: CreateBroadcastDto): Promise<Broadcast> {
+    const { id, title } = createBroadcastDto;
+
+    const broadcast = this.broadcastRepository.create({
+      id,
+      title,
+      viewers: 0,
+      startTime: new Date(),
+      member: null, // 현재 방송자에 대한 부분은 논의 후 로직 적용
+    });
+
+    return await this.broadcastRepository.save(broadcast);
+  }
+}

--- a/apps/media/src/broadcast/dto/createBroadcast.dto.ts
+++ b/apps/media/src/broadcast/dto/createBroadcast.dto.ts
@@ -1,0 +1,5 @@
+export class CreateBroadcastDto {
+  id: string; // broadcast uuid
+  title: string; // 방송 제목
+  memberId: number; // 방송 진행자 id
+}

--- a/apps/media/src/common/responses/exceptions/errorStatus.ts
+++ b/apps/media/src/common/responses/exceptions/errorStatus.ts
@@ -9,7 +9,7 @@ export class ErrorStatus {
   static readonly UNAUTHORIZED = new ErrorStatus(400, 'COMMON_4001', '인증되지 않은 요청입니다.');
 
   // User Errors
-  static readonly USER_NOT_FOUND = new ErrorStatus(400, 'MEMBER_4000', '사용자를 찾을 수 없습니다.');
+  static readonly USER_NOT_FOUND = new ErrorStatus(404, 'MEMBER_4000', '사용자를 찾을 수 없습니다.');
 
   static readonly INVALID_PASSWORD = new ErrorStatus(400, 'MEMBER_4001', '잘못된 비밀번호입니다.');
 
@@ -23,4 +23,7 @@ export class ErrorStatus {
     '방에 방송자가 이미 존재 합니다.',
   );
   static readonly TRANSPORT_NOT_FOUND = new ErrorStatus(404, 'MEDIA_4002', 'TRANSPORT 정보가 존재하지 않습니다.');
+
+  // Broadcast Errors
+  static readonly BROADCAST_NOT_FOUND = new ErrorStatus(404, 'BROADCAST_4000', '방송 정보가 존재하지 않습니다.');
 }

--- a/apps/media/src/member/enum/field.enum.ts
+++ b/apps/media/src/member/enum/field.enum.ts
@@ -1,0 +1,5 @@
+export enum FieldEnum {
+  'WEB' = 'WEB',
+  'AND' = 'AND',
+  'IOS' = 'IOS',
+}

--- a/apps/media/src/member/member.entity.ts
+++ b/apps/media/src/member/member.entity.ts
@@ -1,0 +1,38 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { FieldEnum } from './enum/field.enum';
+
+@Entity()
+export class Member {
+  @PrimaryGeneratedColumn({ name: 'memberId' })
+  id: number;
+
+  @Column({ length: 25, nullable: true })
+  name: string;
+
+  @Column({ length: 100, nullable: true })
+  email: string;
+
+  @Column({ type: 'text', nullable: true })
+  profileImage: string;
+
+  @Column({ name: 'camperId', nullable: true })
+  camperId: string;
+
+  @Column({ nullable: true })
+  filed: FieldEnum;
+
+  @Column({ type: 'text', nullable: true })
+  github: string;
+
+  @Column({ type: 'text', nullable: true })
+  linkedin: string;
+
+  @Column({ type: 'text', nullable: true })
+  blog: string;
+
+  @CreateDateColumn({ name: 'createdAt' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updatedAt' })
+  updatedAt: Date;
+}

--- a/apps/media/src/member/member.module.ts
+++ b/apps/media/src/member/member.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class MemberModule {}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
- #135 

## ✨ 구현 기능 명세
- [x] broadcast module 생성
- [x] broadcast entity 생성 ( api의 broadcast entity랑 통일 )
- [x] 방송 생성 서비스 로직
- [x] 시청자 증감 서비스 로직

## 🎁 PR Point
### broadcast entity 필드
- startTime과 createdAt 각각의 역할을 잘 모르겠음
- startTime과 createdAt이 시간과 날짜를 분리해서 나타내는 거라면, 하나의 변수로 합치는 것이 더 자연스러운 듯함

### 방송 생성 서비스 로직
- 문제점
  - 하나의 rdb에 대하여 api 서버와 media 서버에서 동시에 접근 제어를 하는 상황
  - 그렇다 보니, broadcast에 대한 부분만 필요한 상황인데, member entity에 대해서 one-to-one 연결이 되어있다 보니, 가져와야하는 상황이 발생
  - 우선 member entity도 동일하게 들고 와 사용
- 결론
  - 현재 broadcast의 member에 대해서는 null 값으로 방송 생성 서비스 로직 구현

### 시청자 수 증감 서비스 로직
- save와 update
  - 시청자 수 처럼 자주 바뀌는 변경이 매우 잦은 부분에 대해서 성능적인 이점을 취하기 위해서 save 대신 update를 사용
  - 또한, 성능 이점을 가져가기 위하여 데이터베이스 레벨에서 직접 증감을 하도록 변경
    - 기존에 transaction이 service + db에 묶여 있어야 할 부분에서 db부분에서만 transaction이 걸리게 되어 성능적인 이점이 존재


## 😭 어려웠던 점
- 하나의 db에 대해서 두 서버에서 접근을 하는 경우에 대한 케이스로 방향성을 결정했었으나, 테이블 동기화 작업이 필요한 부분이 불편하게 느껴졌음
- 초반에만 해준다면 문제가 없다고 판단했지만, 정말 추후에 수정할 부분이 적은지는 다시 한번 고려해볼 사항인듯 함