### PR TITLE
[Refactor] producers 종속 범위 제한 및 filter를 이용한 에러 처리

### DIFF
--- a/apps/media/src/common/filter/webSocketException.filter.ts
+++ b/apps/media/src/common/filter/webSocketException.filter.ts
@@ -6,16 +6,23 @@ import { Socket } from 'socket.io';
 export class WebSocketExceptionFilter extends BaseWsExceptionFilter {
   catch(exception: WsException, host: ArgumentsHost) {
     const client = host.switchToWs().getClient<Socket>();
+    const event = host.switchToWs().getPattern();
+
     const error = exception.getError() as {
       status: number;
       code: string;
       message: string;
     };
 
-    client.emit('error', {
-      status: error.status,
-      code: error.code,
-      message: error.message,
-    });
+    const wsResponse = {
+      event,
+      data: {
+        status: error.status || 'error',
+        message: error.message || 'Internal server error',
+        code: error.code || 500,
+      },
+    };
+
+    client.emit('exception', wsResponse);
   }
 }

--- a/apps/media/src/common/responses/exceptions/errorStatus.ts
+++ b/apps/media/src/common/responses/exceptions/errorStatus.ts
@@ -23,6 +23,11 @@ export class ErrorStatus {
     '방에 방송자가 이미 존재 합니다.',
   );
   static readonly TRANSPORT_NOT_FOUND = new ErrorStatus(404, 'MEDIA_4002', 'TRANSPORT 정보가 존재하지 않습니다.');
+  static readonly NO_HAVE_PRODUCER_TRANSPORT_IN_ROOM = new ErrorStatus(
+    404,
+    'MEDIA_4003',
+    '방에 PRODUCER TRANSPORT가 존재하지 않습니다.',
+  );
 
   // Broadcast Errors
   static readonly BROADCAST_NOT_FOUND = new ErrorStatus(404, 'BROADCAST_4000', '방송 정보가 존재하지 않습니다.');

--- a/apps/media/src/sfu/sfu.gateway.ts
+++ b/apps/media/src/sfu/sfu.gateway.ts
@@ -6,8 +6,11 @@ import { ConnectTransportDto } from './dto/transport-params.interface';
 import { CreateProducerDto } from './dto/create-producer.dto';
 import { CreateConsumerDto } from './dto/create-consumer.dto';
 import { CreateTransportDto } from './dto/create-transport.dto';
+import { UseFilters } from '@nestjs/common';
+import { WebSocketExceptionFilter } from 'src/common/filter/webSocketException.filter';
 
 @WebSocketGateway({ cors: { origin: '*', methods: ['GET', 'POST'] } })
+@UseFilters(WebSocketExceptionFilter)
 export class SfuGateway {
   @WebSocketServer()
   server: Server;
@@ -21,73 +24,51 @@ export class SfuGateway {
 
   @SubscribeMessage('createRoom')
   async handleCreateRoom() {
-    try {
-      const room = await this.workerService.createRoom();
-      this.sfuService.setRoom(room);
-
-      return { roomId: room.id };
-    } catch (error) {
-      return error;
-    }
+    const room = await this.workerService.createRoom();
+    this.sfuService.setRoom(room);
+    return { roomId: room.id };
   }
 
   @SubscribeMessage('createTransport')
   async handleCreateTransport(@MessageBody() params: CreateTransportDto) {
-    try {
-      const { isProducer } = params;
+    const { isProducer } = params;
+    const transport = await this.sfuService.createTransport(params);
 
-      const transport = await this.sfuService.createTransport(params);
-
-      return {
-        transportId: transport.id,
-        isProducer,
-        iceParameters: transport.iceParameters,
-        iceCandidates: transport.iceCandidates,
-        dtlsParameters: transport.dtlsParameters,
-      };
-    } catch (error) {
-      return error;
-    }
+    return {
+      transportId: transport.id,
+      isProducer,
+      iceParameters: transport.iceParameters,
+      iceCandidates: transport.iceCandidates,
+      dtlsParameters: transport.dtlsParameters,
+    };
   }
 
   @SubscribeMessage('connectTransport')
   async handleConnectTransport(@MessageBody() params: ConnectTransportDto) {
-    try {
-      const isProducer = await this.sfuService.connectTransport(params);
+    const isProducer = await this.sfuService.connectTransport(params);
 
-      return {
-        connected: true,
-        isProducer,
-      };
-    } catch (error) {
-      return error;
-    }
+    return {
+      connected: true,
+      isProducer,
+    };
   }
 
   @SubscribeMessage('createProducer')
   async handleCreateProducer(@MessageBody() params: CreateProducerDto) {
-    try {
-      const producer = await this.sfuService.createProducer(params);
+    const producer = await this.sfuService.createProducer(params);
 
-      return {
-        producerId: producer.id,
-      };
-    } catch (error) {
-      return error;
-    }
+    return {
+      producerId: producer.id,
+    };
   }
 
   @SubscribeMessage('createConsumer')
   async handleCreateConsumer(@MessageBody() params: CreateConsumerDto) {
-    try {
-      const consumers = await this.sfuService.createConsumer(params);
+    const consumers = await this.sfuService.createConsumer(params);
 
-      return {
-        consumers,
-      };
-    } catch (error) {
-      return error;
-    }
+    return {
+      consumers,
+    };
   }
 
   //TODO: 방송종료

--- a/apps/media/src/sfu/sfu.service.ts
+++ b/apps/media/src/sfu/sfu.service.ts
@@ -143,15 +143,25 @@ export class SfuService {
       rtpParameters,
     });
 
-    if (!this.producers.has(roomId)) {
-      this.producers.set(roomId, []);
+    if (!this.producers.has(transportId)) {
+      this.producers.set(transportId, []);
     }
-    this.producers.get(roomId).push(producer);
+    this.producers.get(transportId).push(producer);
     return producer;
   }
 
   getProducersByRoomId(roomId: string): mediasoup.types.Producer[] {
-    return this.producers[roomId];
+    const roomInfo = this.roomTransports.get(roomId);
+    if (!roomInfo) {
+      throw new CustomWsException(ErrorStatus.ROOM_NOT_FOUND);
+    }
+
+    const producersTransportId = roomInfo.producerTransportId;
+    if (!producersTransportId) {
+      throw new CustomWsException(ErrorStatus.NO_HAVE_PRODUCER_TRANSPORT_IN_ROOM);
+    }
+
+    return this.producers[producersTransportId];
   }
 
   //consumer
@@ -159,19 +169,16 @@ export class SfuService {
     const { transportId, rtpCapabilities, roomId } = params;
 
     const room = this.getRoom(roomId);
-
     if (!room) {
       throw new CustomWsException(ErrorStatus.ROOM_NOT_FOUND);
     }
 
     const canConsume = await this.canConsume(room, rtpCapabilities);
-
     if (!canConsume) {
       throw new CustomWsException(ErrorStatus.CANNOT_CONSUME_PRODUCER);
     }
 
     const transport = this.getTransport(roomId, transportId);
-
     if (!transport) {
       throw new CustomWsException(ErrorStatus.TRANSPORT_NOT_FOUND);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
#141 

## ✨ 구현 기능 명세
- producers의 key값 roomId -> transportId
- getProducersByRoomId 예외처리 로직 추가
- WebSocketExceptionFilter를 통한 error 로직
- sfu.gateway.ts -> try-catch 제거

## 🎁 PR Point
- ws error 시, client 에서 'exception' 이벤트를 등록해서 받아야 함
  ``` ts
  const wsResponse = {
      event,
      data: {
        status: error.status || 'error',
        message: error.message || 'Internal server error',
        code: error.code || 500,
      },
    };

    client.emit('exception', wsResponse);
  ``` 

## 😭 어려웠던 점
