### PR TITLE
[Feat] 방송 종료, 시청 종료 이벤트 구현

### DIFF
--- a/apps/media/src/sfu/sfu.gateway.ts
+++ b/apps/media/src/sfu/sfu.gateway.ts
@@ -86,5 +86,17 @@ export class SfuGateway {
     }
   }
 
-  //스트림 일시 중단
+  //시청 종료
+  @SubscribeMessage('leaveBroadcast')
+  handleLeaveBroadcast(@MessageBody('transportId') transportId: string, @MessageBody('roomId') roomId: string) {
+    try {
+      this.sfuService.deleteConsumers(roomId, transportId);
+
+      return {
+        success: true,
+      };
+    } catch (error) {
+      return error;
+    }
+  }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #149 

## ✨ 구현 기능 명세
- stopBroadcast 이벤트 구현
- leaveBroadcast 이벤트 구현

## 🎁 PR Point
- stopBroadcast 이벤트는 service계층에서 cleanupRoom 함수가 실행되면 router가 close되고, 기존에 transport, producer, consumer에 등록해놓은 close이벤트들이 발생하면서 연쇄적으로 모두 종료되도록 구현하였습니다.
- leaveBroadcast 이벤트는 보고있던 방송의 roomId와 시청자의 tranportId를 받아서 transport를 닫고, 기존에 등록한 이벤트로 연쇄적으로 consumer까지 종료되도록 구현했습니다.
