### PR TITLE
:bug: [Fix]: 방송 리스트 조회 응답 수정

### DIFF
--- a/apps/api/src/broadcast/broadcast.controller.ts
+++ b/apps/api/src/broadcast/broadcast.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { BroadcastService } from './broadcast.service';
 import { SuccessStatus } from '../common/responses/bases/successStatus';
+import { BroadcastListResponseDto } from './dto/broadcast-list-response.dto';
 
 @Controller('broadcasts')
 export class BroadcastController {
@@ -9,6 +10,6 @@ export class BroadcastController {
   @Get()
   async getAll() {
     const broadcasts = await this.broadcastService.getAll();
-    return SuccessStatus.OK(broadcasts);
+    return SuccessStatus.OK(BroadcastListResponseDto.from(broadcasts));
   }
 }

--- a/apps/api/src/broadcast/broadcast.service.ts
+++ b/apps/api/src/broadcast/broadcast.service.ts
@@ -8,6 +8,9 @@ export class BroadcastService {
   constructor(@InjectRepository(Broadcast) private readonly broadcastRepository: Repository<Broadcast>) {}
 
   async getAll() {
-    return this.broadcastRepository.find();
+    return this.broadcastRepository
+      .createQueryBuilder('broadcast')
+      .leftJoinAndSelect('broadcast.member', 'member')
+      .getMany();
   }
 }

--- a/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
@@ -1,0 +1,24 @@
+import { FieldEnum } from '../../member/enum/field.enum';
+import { Broadcast } from '../broadcast.entity';
+
+export class BroadcastListResponseDto {
+  broadcastId: string;
+  broadcastTitle: string;
+  thumbnail: string;
+  camperId: string;
+  profileImage: string;
+  field: FieldEnum;
+
+  static from(broadcasts: Broadcast[]) {
+    return broadcasts.map(broadcast => {
+      const dto = new BroadcastListResponseDto();
+      dto.broadcastId = broadcast.id;
+      dto.broadcastTitle = broadcast.title;
+      dto.thumbnail = broadcast.thumbnail;
+      dto.camperId = broadcast.member ? broadcast.member.camperId : '';
+      dto.profileImage = broadcast.member ? broadcast.member.profileImage : '';
+      dto.field = broadcast.member ? broadcast.member.filed : FieldEnum.WEB;
+      return dto;
+    });
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #167

## ✨ 구현 기능 명세
- API 명세서에 맞게 응답을 수정했습니다.
- 현재 로그인 기능이 없어서 멤버 테이블과 조인을 하면 null이 반환되서 때문에 아래 코드처럼 임시로 기본값 설정을 해줬습니다.
``` ts
    dto.camperId = broadcast.member ? broadcast.member.camperId : '';
    dto.profileImage = broadcast.member ? broadcast.member.profileImage : '';
    dto.field = broadcast.member ? broadcast.member.filed : FieldEnum.WEB;
```
## 🎁 PR Point
<img width="533" alt="image" src="https://github.com/user-attachments/assets/3a75e245-1b14-4e88-857b-80e938d274ef">

## 😭 어려웠던 점
