### PR TITLE
[Feat] 방송 리스트 레이아웃 UI 구현

### DIFF
--- a/apps/client/src/components/LiveList.tsx
+++ b/apps/client/src/components/LiveList.tsx
@@ -1,0 +1,28 @@
+import LiveCard from './LiveCard';
+
+interface LiveInfo {
+  broadcastId: string;
+  broadcastTitle: string;
+  thumbnail: string;
+  camperId: string;
+  profileImage: string;
+  field: string;
+}
+
+function LiveList({ liveInfos }: { liveInfos: LiveInfo[] }) {
+  return (
+    <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-[clamp(40px,2vw,60px)] p-15 w-[95%] max-w-[1920px] place-items-center">
+      {liveInfos.map(liveInfo => (
+        <LiveCard
+          key={liveInfo.broadcastId}
+          title={liveInfo.broadcastTitle}
+          userId={liveInfo.camperId}
+          profileUrl={liveInfo.profileImage}
+          thumbnailUrl={liveInfo.thumbnail}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default LiveList;

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -1,34 +1,100 @@
-import LiveCard from '@/components/LiveCard';
+import LiveList from '@/components/LiveList';
+
+const liveInfos = [
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 1',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J001',
+    profileImage: '/images/duck.png',
+    field: 'WEB',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 22',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J225',
+    profileImage: '/images/duck.png',
+    field: 'WEB',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 333',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J389',
+    profileImage: '/images/duck.png',
+    field: 'AND',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 4444',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'S486',
+    profileImage: '/images/duck.png',
+    field: 'IOS',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 55555',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J023',
+    profileImage: '/images/duck.png',
+    field: 'WEB',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 666666',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J126',
+    profileImage: '/images/duck.png',
+    field: 'WEB',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 7777777',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J219',
+    profileImage: '/images/duck.png',
+    field: 'WEB',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 88888888',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J273',
+    profileImage: '/images/duck.png',
+    field: 'IOS',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 999999999',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'K101',
+    profileImage: '/images/duck.png',
+    field: 'AND',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 테스트 123456789',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'S202',
+    profileImage: '/images/duck.png',
+    field: 'IOS',
+  },
+  {
+    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
+    broadcastTitle: '방송 제목 테스트 123456789123456789',
+    thumbnail: '/images/zoom_membership_bg.png',
+    camperId: 'J299',
+    profileImage: '/images/duck.png',
+    field: 'WEB',
+  },
+];
 
 export default function Home() {
-  const liveInfos = [
-    {
-      id: 1,
-      title: '방송 제목1',
-      userId: 'J999',
-      profileUrl: '/images/duck.png',
-      thumbnailUrl: '/images/zoom_membership_bg.png',
-    },
-    { id: 2, title: '방송 제목2222222222222222222222', userId: 'K888', profileUrl: '', thumbnailUrl: '' },
-    { id: 3, title: '방송 제목3', userId: 'S777', profileUrl: '', thumbnailUrl: '' },
-    { id: 4, title: '방송 제목4', userId: 'J666', profileUrl: '', thumbnailUrl: '' },
-    { id: 5, title: '방송 제목5555555555555', userId: 'J555', profileUrl: '', thumbnailUrl: '' },
-    { id: 6, title: '방송 제목6', userId: 'J444', profileUrl: '', thumbnailUrl: '' },
-    { id: 7, title: '방송 제목7', userId: 'J333', profileUrl: '', thumbnailUrl: '' },
-    { id: 8, title: '방송 제목8', userId: 'J222', profileUrl: '', thumbnailUrl: '' },
-    { id: 9, title: '방송 제목9', userId: 'J111', profileUrl: '', thumbnailUrl: '' },
-  ];
   return (
-    <div className="flex flex-wrap p-8 gap-10">
-      {liveInfos.map(liveInfo => (
-        <LiveCard
-          key={liveInfo.id}
-          title={liveInfo.title}
-          userId={liveInfo.userId}
-          profileUrl={liveInfo.profileUrl}
-          thumbnailUrl={liveInfo.thumbnailUrl}
-        />
-      ))}
+    <div className="flex justify-center w-full">
+      <LiveList liveInfos={liveInfos} />
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> - #34 

## ✨ 구현 기능 명세

- 방송 미리보기 카드 레이아웃 UI 구현

## 🎁 PR Point

![2024-11-1621-53-46-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/91d2be3b-2d91-4923-b3ec-65bea37f664c)

```html
<div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-[clamp(40px,2vw,60px)] p-15 w-[95%] max-w-[1920px] place-items-center">
  {liveInfos.map(liveInfo => (
    <LiveCard />
  ))}
</div>
```

1. 레이아웃 설정
- grid: CSS Grid 레이아웃을 사용
- place-items-center: 각 grid 셀 내에서 아이템을 가운데 정렬

2. 반응형 그리드 열 설정
- grid-cols-1: 기본적으로 1열
- min-[690px]:grid-cols-2: 화면 너비 690px 이상일 때 2열
- min-[1040px]:grid-cols-3: 화면 너비 1040px 이상일 때 3열
- min-[1380px]:grid-cols-4: 화면 너비 1380px 이상일 때 4열
- min-[1720px]:grid-cols-5: 화면 너비 1720px 이상일 때 5열

3. 간격과 패딩
- gap-[clamp(40px,2vw,60px)]: 그리드 아이템 간의 간격
 - 최소: 40px
 - 기본: 화면 너비의 2%
 - 최대: 60px
- p-15: 전체 패딩 15단위

4. 너비 설정
- w-[95%]: 컨테이너의 너비를 화면의 95%로 설정
- max-w-[1920px]: 최대 너비를 1920px로 제한

각 breakpoint는 LiveCard의 너비(300px)와 gap(최소 40px)을 고려하여 계산됐다.
- 690px = (300px × 2) + 40px + 여유공간
- 1040px = (300px × 3) + (40px × 2) + 여유공간
- 1380px = (300px × 4) + (40px × 3) + 여유공간
- 1720px = (300px × 5) + (40px × 4) + 여유공간

## 😭 어려웠던 점

### 반응형 레이아웃

처음에는 `flex-wrap`과 `justify-between` 속성을 이용하여 LiveCard 간의 간격을 동일하게 하고, 창의 크기가 줄어들었을때 자동으로 줄바꿈이 되도록 구현하려했다.

```html
<div className="flex flex-wrap justify-start p-14 gap-10 w-full max-w-[1920px] mx-auto">
  {liveInfos.map(liveInfo => (
    <LiveCard />
  ))}
</div>
```

![image](https://github.com/user-attachments/assets/6575d3ed-02f9-437f-b88f-11579968658f)

마지막에 개수가 애매하게 남는 줄의 배치가 이상하다. `justify-start` 대신 `justify-around`를 사용해도 가장 아랫줄의 카드들 간의 gap이 윗줄과 다른 것은 여전했다.

그래서 `justify-between`에서 `justify-start`로 바꿨다.

![image](https://github.com/user-attachments/assets/9375f02a-6773-448e-8090-fac51b7baa8c)

이제는 양쪽 패딩이 이븐하지 않다. 거슬린다.
그래서 결국 flex-wrap이 아닌 grid를 사용해보기로 했다.

```html
<div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-[clamp(40px,2vw,60px)] p-15 w-[95%] max-w-[1920px] place-items-center">
```

![image](https://github.com/user-attachments/assets/33b3a3f2-661f-4a71-8ebd-cd6b82d438d1)

grid로 반응형 레이아웃을 적용하니 원하는 모양을 만들 수 있었다.