### PR TITLE
[Feat] 방송 클릭 이벤트 리스너 구현

### DIFF
--- a/apps/client/src/components/LiveCard.tsx
+++ b/apps/client/src/components/LiveCard.tsx
@@ -1,13 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+
 interface LiveCardProps {
+  liveId: string;
   title: string;
   userId: string;
   profileUrl?: string;
   thumbnailUrl: string;
 }
 
-const LiveCard = ({ title, userId, profileUrl, thumbnailUrl }: LiveCardProps) => {
+const LiveCard = ({ liveId, title, userId, profileUrl, thumbnailUrl }: LiveCardProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/live/${liveId}`);
+  };
+
   return (
-    <div className="w-[300px] h-[225px] relative overflow-hidden group cursor-pointer rounded-xl transition-all duration-300 ease-in-out hover:shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:scale-[1.02] bg-surface-alt">
+    <div
+      onClick={handleClick}
+      className="w-[300px] h-[225px] relative overflow-hidden group cursor-pointer rounded-xl transition-all duration-300 ease-in-out hover:shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:scale-[1.02] bg-surface-alt"
+    >
       {/* 썸네일 */}
       <div className="w-full aspect-video rounded-xl bg-[#161817]">
         {thumbnailUrl && <img src={thumbnailUrl} alt={title} className="w-full h-full object-cover " />}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> - #53 

## ✨ 구현 기능 명세

방송 미리보기 카드 클릭 시 해당 방송으로 이동하는 이벤트 리스너 구현
예를 들어, `liveId`가 "abcdefg12345"라면 "https://cam-on.site/live/abcdefg12345"로 이동

## 🎁 PR Point

## 😭 어려웠던 점
