### PR TITLE
[Feat] 방송 리스트 조회 기능 구현

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
+    "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.456.0",

--- a/apps/client/src/components/LiveList.tsx
+++ b/apps/client/src/components/LiveList.tsx
@@ -1,20 +1,13 @@
+import { LiveInfo } from '@/types/liveTypes';
 import LiveCard from './LiveCard';
 
-interface LiveInfo {
-  broadcastId: string;
-  broadcastTitle: string;
-  thumbnail: string;
-  camperId: string;
-  profileImage: string;
-  field: string;
-}
-
-function LiveList({ liveInfos }: { liveInfos: LiveInfo[] }) {
+function LiveList({ liveList }: { liveList: LiveInfo[] }) {
   return (
     <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-[clamp(40px,2vw,60px)] p-15 w-[95%] max-w-[1920px] place-items-center">
-      {liveInfos.map(liveInfo => (
+      {liveList.map(liveInfo => (
         <LiveCard
           key={liveInfo.broadcastId}
+          liveId={liveInfo.broadcastId}
           title={liveInfo.broadcastTitle}
           userId={liveInfo.camperId}
           profileUrl={liveInfo.profileImage}

--- a/apps/client/src/components/LiveList.tsx
+++ b/apps/client/src/components/LiveList.tsx
@@ -1,19 +1,20 @@
 import { LiveInfo } from '@/types/liveTypes';
 import LiveCard from './LiveCard';
 
-function LiveList({ liveList }: { liveList: LiveInfo[] }) {
+function LiveList({ liveList }: { liveList: LiveInfo[] | null }) {
   return (
     <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-[clamp(40px,2vw,60px)] p-15 w-[95%] max-w-[1920px] place-items-center">
-      {liveList.map(liveInfo => (
-        <LiveCard
-          key={liveInfo.broadcastId}
-          liveId={liveInfo.broadcastId}
-          title={liveInfo.broadcastTitle}
-          userId={liveInfo.camperId}
-          profileUrl={liveInfo.profileImage}
-          thumbnailUrl={liveInfo.thumbnail}
-        />
-      ))}
+      {liveList &&
+        liveList.map(liveInfo => (
+          <LiveCard
+            key={liveInfo.broadcastId}
+            liveId={liveInfo.broadcastId}
+            title={liveInfo.broadcastTitle}
+            userId={liveInfo.camperId}
+            profileUrl={liveInfo.profileImage}
+            thumbnailUrl={liveInfo.thumbnail}
+          />
+        ))}
     </div>
   );
 }

--- a/apps/client/src/components/common/ErrorCharacter.tsx
+++ b/apps/client/src/components/common/ErrorCharacter.tsx
@@ -1,0 +1,87 @@
+interface ErrorCharacterProps {
+  size?: number;
+  message?: string;
+}
+
+const ErrorCharacter = ({ size = 300, message = 'Error' }: ErrorCharacterProps): JSX.Element => {
+  return (
+    <div style={{ width: size, height: size }} className="flex flex-col items-center">
+      <svg viewBox="0 0 200 200" className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
+        {/* Shadow */}
+        <ellipse cx="100" cy="180" rx="65" ry="12" fill="#6366F1" opacity="0.2" />
+
+        {/* Body */}
+        <circle cx="100" cy="100" r="60" fill="#818CF8" />
+
+        {/* Left Ear/Antenna */}
+        <path d="M55 55 Q48 30 68 15" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <circle cx="68" cy="15" r="10" fill="#EF4444">
+          <animate attributeName="opacity" values="1;0.5;1" dur="2s" repeatCount="indefinite" />
+        </circle>
+
+        {/* Right Ear/Antenna */}
+        <path d="M145 55 Q152 30 132 15" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <circle cx="132" cy="15" r="10" fill="#EF4444">
+          <animate attributeName="opacity" values="1;0.5;1" dur="2s" repeatCount="indefinite" begin="1s" />
+        </circle>
+
+        {/* Eyebrows */}
+        <path d="M85 75 L95 80" stroke="#1E1B4B" strokeWidth="4" strokeLinecap="round" />
+        <path d="M115 75 L105 80" stroke="#1E1B4B" strokeWidth="4" strokeLinecap="round" />
+
+        {/* Camera Lens/Eye */}
+        <circle cx="100" cy="90" r="26" fill="#1E1B4B" />
+        <circle cx="100" cy="90" r="21" fill="#312E81" />
+        <circle cx="100" cy="90" r="16" fill="#1E1B4B" />
+        <circle cx="94" cy="84" r="7" fill="white" opacity="0.7" />
+
+        {/* Frowning Mouth */}
+        <path d="M80 120 Q100 110 120 120" fill="none" stroke="white" strokeWidth="5" strokeLinecap="round" />
+
+        {/* Blush */}
+        <circle cx="70" cy="110" r="10" fill="#EF4444" opacity="0.4" />
+        <circle cx="130" cy="110" r="10" fill="#EF4444" opacity="0.4" />
+
+        {/* Arms down */}
+        <path d="M50 100 Q45 120 50 140" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <path d="M150 100 Q155 120 150 140" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+
+        {/* Legs */}
+        <path d="M80 160 L80 185" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <path d="M120 160 L120 185" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+
+        {/* Warning Light */}
+        <g transform="translate(100, 25)">
+          {/* Error text */}
+          <text
+            x="0"
+            y="-15"
+            textAnchor="middle"
+            fontFamily="Pretendard"
+            fontSize="12"
+            fontWeight="bold"
+            fill="#EF4444"
+          >
+            Error!
+          </text>
+
+          {/* Light Effect */}
+          <path d="M-14.4 0 A14.4 12 0 0 1 14.4 0 L14.4 15 L-14.4 15 Z" fill="#FEF2F2" opacity="0.2">
+            <animate attributeName="opacity" values="0.2;0.1;0.2" dur="1.5s" repeatCount="indefinite" />
+          </path>
+
+          {/* Main Light Body */}
+          <path d="M-12 0 A12 10 0 0 1 12 0 L12 12 L-12 12 Z" fill="#EF4444">
+            <animate attributeName="opacity" values="1;0.4;1" dur="1.5s" repeatCount="indefinite" />
+          </path>
+
+          {/* Base */}
+          <rect x="-18" y="12" width="36" height="8" rx="4" fill="#64748B" />
+        </g>
+      </svg>
+      <p className="text-[#EF4444] font-bold mt-4">{message}</p>
+    </div>
+  );
+};
+
+export default ErrorCharacter;

--- a/apps/client/src/components/common/LoadingCharacter.tsx
+++ b/apps/client/src/components/common/LoadingCharacter.tsx
@@ -1,0 +1,89 @@
+interface LoadingCharacterProps {
+  size?: number;
+}
+
+const LoadingCharacter = ({ size = 300 }: LoadingCharacterProps): JSX.Element => {
+  return (
+    <div style={{ width: size, height: size }}>
+      <svg viewBox="0 0 200 200" className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
+        {/*-- Shadow */}
+        <ellipse cx="100" cy="180" rx="65" ry="12" fill="#6366F1" opacity="0.2" />
+
+        {/*-- Body */}
+        <circle cx="100" cy="100" r="60" fill="#818CF8" />
+
+        {/*-- Left Ear/Antenna */}
+        <path d="M55 55 Q48 30 68 15" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <circle cx="68" cy="15" r="10" fill="#EF4444">
+          <animate attributeName="opacity" values="1;0.5;1" dur="2s" repeatCount="indefinite" />
+        </circle>
+
+        {/*-- Right Ear/Antenna */}
+        <path d="M145 55 Q152 30 132 15" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <circle cx="132" cy="15" r="10" fill="#EF4444">
+          <animate attributeName="opacity" values="1;0.5;1" dur="2s" repeatCount="indefinite" begin="1s" />
+        </circle>
+
+        {/*-- Camera Lens/Eye */}
+        <circle cx="100" cy="90" r="26" fill="#1E1B4B" />
+        <circle cx="100" cy="90" r="21" fill="#312E81" />
+        <circle cx="100" cy="90" r="16" fill="#1E1B4B" />
+        <circle cx="94" cy="84" r="7" fill="white" opacity="0.7" />
+
+        {/*-- Smile (static) */}
+        <path d="M80 115 Q100 128 120 115" fill="none" stroke="white" strokeWidth="5" strokeLinecap="round" />
+
+        {/*-- Blush */}
+        <circle cx="70" cy="110" r="10" fill="#FCA5A5" opacity="0.6" />
+        <circle cx="130" cy="110" r="10" fill="#FCA5A5" opacity="0.6" />
+
+        {/*-- Legs */}
+        <path d="M80 160 L80 185" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <path d="M120 160 L120 185" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+
+        {/*-- Arms holding display */}
+        <path d="M50 100 Q40 120 50 140" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+        <path d="M150 100 Q160 120 150 140" fill="none" stroke="#818CF8" strokeWidth="16" strokeLinecap="round" />
+
+        {/*-- Display */}
+        <rect x="50" y="130" width="100" height="60" rx="5" fill="white" />
+
+        {/*-- Loading Spinner */}
+        <g transform="translate(100 150)">
+          <circle cx="0" cy="0" r="12" stroke="#818CF8" strokeWidth="3" fill="none" />
+          <path d="M 12 0 A 12 12 0 0 1 -12 0" stroke="#EF4444" strokeWidth="3" fill="none" strokeLinecap="round">
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 0 0"
+              to="360 0 0"
+              dur="1s"
+              repeatCount="indefinite"
+            />
+          </path>
+        </g>
+
+        {/*-- Loading Text */}
+        <text
+          x="100"
+          y="175"
+          textAnchor="middle"
+          fontFamily="Pretendard"
+          fontSize="14"
+          fontWeight="bold"
+          fill="#818CF8"
+        >
+          Loading
+          <animate
+            attributeName="text-content"
+            values="Loading.;Loading..;Loading...;Loading...."
+            dur="1.5s"
+            repeatCount="indefinite"
+          />
+        </text>
+      </svg>
+    </div>
+  );
+};
+
+export default LoadingCharacter;

--- a/apps/client/src/env.d.ts
+++ b/apps/client/src/env.d.ts
@@ -1,5 +1,6 @@
 interface ImportMetaEnv {
   readonly VITE_MEDIASERVER_URL: string;
+  readonly VITE_API_SERVER_URL: string;
 }
 
 interface ImportMeta {

--- a/apps/client/src/hooks/useAPI.ts
+++ b/apps/client/src/hooks/useAPI.ts
@@ -1,0 +1,26 @@
+import axiosInstance from '@/services/axios';
+import { AxiosRequestConfig } from 'axios';
+import { useEffect, useState } from 'react';
+
+export const useAPI = (apiInfo: AxiosRequestConfig) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const result = await axiosInstance.request(apiInfo);
+        setData(result.data.data);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error());
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { data, isLoading, error };
+};

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -1,37 +1,16 @@
-import { LiveInfo } from '@/types/liveTypes';
 import LiveList from '@/components/LiveList';
-
-import { useEffect, useState } from 'react';
 import LoadingCharacter from '@components/common/LoadingCharacter';
 import ErrorCharacter from '@components/common/ErrorCharacter';
-import { getLiveList } from '@/services/axios';
+import { useAPI } from '@/hooks/useAPI';
 
 export default function Home() {
-  const [liveList, setLiveList] = useState<LiveInfo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string>('');
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await getLiveList();
-        setLiveList(data);
-      } catch (err) {
-        console.error('Failed to fetch live data: ', err);
-        setError('방송 목록을 불러오는데 실패했습니다.');
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchData();
-  }, []);
+  const { data: liveList, isLoading, error } = useAPI({ url: '/v1/broadcasts' });
 
   return (
     <div className="flex justify-center w-full h-[calc(100vh-88px)]">
       {error ? (
         <div className="flex justify-center items-center flex-1">
-          <ErrorCharacter message={error} />
+          <ErrorCharacter message={error.message} />
         </div>
       ) : isLoading ? (
         <div className="flex justify-center items-center flex-1">

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -1,100 +1,57 @@
+import { LiveInfo } from '@/types/liveTypes';
 import LiveList from '@/components/LiveList';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
 
-const liveInfos = [
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 1',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J001',
-    profileImage: '/images/duck.png',
-    field: 'WEB',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 22',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J225',
-    profileImage: '/images/duck.png',
-    field: 'WEB',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 333',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J389',
-    profileImage: '/images/duck.png',
-    field: 'AND',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 4444',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'S486',
-    profileImage: '/images/duck.png',
-    field: 'IOS',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 55555',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J023',
-    profileImage: '/images/duck.png',
-    field: 'WEB',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 666666',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J126',
-    profileImage: '/images/duck.png',
-    field: 'WEB',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 7777777',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J219',
-    profileImage: '/images/duck.png',
-    field: 'WEB',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 88888888',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J273',
-    profileImage: '/images/duck.png',
-    field: 'IOS',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 999999999',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'K101',
-    profileImage: '/images/duck.png',
-    field: 'AND',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 테스트 123456789',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'S202',
-    profileImage: '/images/duck.png',
-    field: 'IOS',
-  },
-  {
-    broadcastId: 'cbf4b8de0ce38a7c8c8c37e4eda54889',
-    broadcastTitle: '방송 제목 테스트 123456789123456789',
-    thumbnail: '/images/zoom_membership_bg.png',
-    camperId: 'J299',
-    profileImage: '/images/duck.png',
-    field: 'WEB',
-  },
-];
+const baseUrl = import.meta.env.VITE_API_SERVER_URL;
+
+const getLiveList = async (field?: 'WEB' | 'AND' | 'IOS'): Promise<LiveInfo[]> => {
+  const response = await axios.get(`${baseUrl}/v1/broadcast/list`, {
+    headers: { 'Content-Type': 'application/json' },
+    params: {
+      field: field,
+    },
+  });
+  if (!response.data.success) {
+    throw new Error(response.data.message);
+  }
+  return response.data.data;
+};
 
 export default function Home() {
+  const [liveList, setLiveList] = useState<LiveInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getLiveList();
+        setLiveList(data);
+      } catch (err) {
+        console.error('Failed to fetch live data: ', err);
+        setError('방송 목록을 불러오는데 실패했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
   return (
-    <div className="flex justify-center w-full">
-      <LiveList liveInfos={liveInfos} />
+    <div className="flex justify-center w-full h-[calc(100vh-88px)]">
+      {error ? (
+        <div className="flex justify-center items-center flex-1">
+          <div className="text-text-danger">{error}</div>
+        </div>
+      ) : isLoading ? (
+        <div className="flex justify-center items-center flex-1">
+          <div>로딩 중....</div>
+        </div>
+      ) : (
+        <LiveList liveList={liveList} />
+      )}
     </div>
   );
 }

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -1,24 +1,10 @@
 import { LiveInfo } from '@/types/liveTypes';
 import LiveList from '@/components/LiveList';
-import axios from 'axios';
+
 import { useEffect, useState } from 'react';
 import LoadingCharacter from '@components/common/LoadingCharacter';
 import ErrorCharacter from '@components/common/ErrorCharacter';
-
-const baseUrl = import.meta.env.VITE_API_SERVER_URL;
-
-const getLiveList = async (field?: 'WEB' | 'AND' | 'IOS'): Promise<LiveInfo[]> => {
-  const response = await axios.get(`${baseUrl}/v1/broadcast/list`, {
-    headers: { 'Content-Type': 'application/json' },
-    params: {
-      field: field,
-    },
-  });
-  if (!response.data.success) {
-    throw new Error(response.data.message);
-  }
-  return response.data.data;
-};
+import { getLiveList } from '@/services/axios';
 
 export default function Home() {
   const [liveList, setLiveList] = useState<LiveInfo[]>([]);

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -2,6 +2,8 @@ import { LiveInfo } from '@/types/liveTypes';
 import LiveList from '@/components/LiveList';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
+import LoadingCharacter from '@components/common/LoadingCharacter';
+import ErrorCharacter from '@components/common/ErrorCharacter';
 
 const baseUrl = import.meta.env.VITE_API_SERVER_URL;
 
@@ -43,11 +45,11 @@ export default function Home() {
     <div className="flex justify-center w-full h-[calc(100vh-88px)]">
       {error ? (
         <div className="flex justify-center items-center flex-1">
-          <div className="text-text-danger">{error}</div>
+          <ErrorCharacter message={error} />
         </div>
       ) : isLoading ? (
         <div className="flex justify-center items-center flex-1">
-          <div>로딩 중....</div>
+          <LoadingCharacter />
         </div>
       ) : (
         <LiveList liveList={liveList} />

--- a/apps/client/src/services/axios.ts
+++ b/apps/client/src/services/axios.ts
@@ -8,12 +8,4 @@ const axiosInstance = axios.create({
   timeout: 5000,
 });
 
-export const getLiveList = async (field?: string) => {
-  const response = await axiosInstance.get('/v1/broadcasts', {
-    params: {
-      field: field,
-    },
-  });
-  if (!response.data.success) throw new Error(response.data.message);
-  return response.data.data;
-};
+export default axiosInstance;

--- a/apps/client/src/services/axios.ts
+++ b/apps/client/src/services/axios.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const baseUrl = import.meta.env.VITE_API_SERVER_URL;
+
+const axiosInstance = axios.create({
+  baseURL: baseUrl,
+  headers: { 'Content-Type': 'application/json' },
+  timeout: 5000,
+});
+
+export const getLiveList = async (field?: string) => {
+  const response = await axiosInstance.get('/v1/broadcasts', {
+    params: {
+      field: field,
+    },
+  });
+  if (!response.data.success) throw new Error(response.data.message);
+  return response.data.data;
+};

--- a/apps/client/src/types/liveTypes.ts
+++ b/apps/client/src/types/liveTypes.ts
@@ -1,0 +1,8 @@
+export interface LiveInfo {
+  broadcastId: string;
+  broadcastTitle: string;
+  thumbnail: string;
+  camperId: string;
+  profileImage: string;
+  field: 'WEB' | 'AND' | 'IOS';
+}

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -21,7 +21,7 @@
       "@components/*": ["./src/components/*"],
       "@pages/*": ["./src/pages/*"],
       "@utils/*": ["./src/utils/*"],
-      "@types/*": ["./src/types"]
+      "@types/*": ["./src/types/*"]
     },
     "outDir": "./dist"
   },

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -14,14 +14,5 @@ export default defineConfig({
       '@types': path.resolve(__dirname, './src/types'),
     },
   },
-  server: {
-    proxy: {
-      '/v1': {
-        target: 'https://api.cam-on.site',
-        changeOrigin: true,
-        secure: false,
-      },
-    },
-  },
   base: '/',
 });

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -14,5 +14,14 @@ export default defineConfig({
       '@types': path.resolve(__dirname, './src/types'),
     },
   },
+  server: {
+    proxy: {
+      '/v1': {
+        target: 'https://api.cam-on.site',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
   base: '/',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      axios:
+        specifier: ^1.7.7
+        version: 1.7.7
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -2042,6 +2045,9 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
+  axios@1.7.7:
+    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2914,6 +2920,15 @@ packages:
 
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -4234,6 +4249,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -7121,6 +7139,14 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
+  axios@1.7.7:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   babel-jest@29.7.0(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
@@ -8222,6 +8248,8 @@ snapshots:
   flatted@3.3.1: {}
 
   fn.name@1.1.0: {}
+
+  follow-redirects@1.15.9: {}
 
   for-each@0.3.3:
     dependencies:
@@ -9787,6 +9815,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #174 

## ✨ 구현 기능 명세

- 방송 목록 조회 기능 구현
  - axios 설치
  - api 서버 주소 환경변수(`VITE_API_SERVER_URL`) 타입 정의
  - axios 인스턴스 생성
  - 방송 목록api 요청 함수 작성
- 로딩 컴포넌트 구현
- 에러 컴포넌트 구현

## 🎁 PR Point

- 방송 목록 조회는 현재 되지 않는 상태라서 캡처본이 없습니다...
- 로딩 컴포넌트

![image](https://github.com/user-attachments/assets/0c3c838c-c0ef-46e3-b140-88ab116f77cc)

- 에러 컴포넌트

![image](https://github.com/user-attachments/assets/069686ae-ac88-491f-94c7-2ecadba74493)

## 😭 어려웠던 점

### CORS 에러 발생

![image](https://github.com/user-attachments/assets/39003877-645e-4f26-aded-488510ea4cf2)

CORS 에러가 발생했다. CORS 에러는 브라우저의 SOP(Same-Origin Policy)로 인해 다른 도메인으로부터의 API 요청은 차단되는 것이 원인이다. 요청을 api 서버로 보내고 있는데, 개발 환경에서는 클라이언트의 origin이 배포 환경과 다른 localhost를 사용하기 때문에 발생하는 것으로 생각하여 `vite.config.ts`에 다음과 같이 설정해줬다.

```typescript
export default defineConfig({
  plugins: [react()],
  resolve: {
    alias: {
      // ...
    },
  },
  server: {
    proxy: {
      '/v1': {
        target: 'API 서버 주소',
        changeOrigin: true,
        secure: false,
      },
    },
  },
  base: '/',
});
```

그런데도 안돼서 찾아보니 이런 Proxy 설정은 클라이언트도 로컬이고, 서버도 로컬일때 사용하는 것이라고 한다. 로컬 개발 서버에서는 보통 CORS 설정을 따로 하지 않기 때문에 설정해주는 것이라고 한다. 

지금 와서 생각해보니 `baseUrl`과 Proxy에 설정해준 API 서버 주소가 같은데 Proxy 설정이 당연히 필요할리가 없다...

결국 백엔드에게 CORS 설정해달라고 했더니 해결됐다. 
