### PR TITLE
[Chore] api에 swagger 적용

### DIFF
--- a/apps/api/src/broadcast/broadcast.controller.ts
+++ b/apps/api/src/broadcast/broadcast.controller.ts
@@ -6,18 +6,32 @@ import { BroadcastInfoResponseDto } from './dto/broadcast-info-response.dto';
 import { UpdateBroadcastTitleDto } from './dto/update-broadcast-title.request.dto';
 import { Broadcast } from './broadcast.entity';
 import { CreateBroadcastDto } from './dto/createBroadcast.dto';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { SwaggerTag } from 'src/common/constants/swagger-tag.enum';
+import { ApiSuccessResponse } from 'src/common/decorators/success-res.decorator';
+import { ApiErrorResponse } from 'src/common/decorators/error-res.decorator';
+import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
 
 @Controller('v1/broadcasts')
 export class BroadcastController {
   constructor(private readonly broadcastService: BroadcastService) {}
 
   @Get()
+  @ApiTags(SwaggerTag.MAIN)
+  @ApiOperation({ summary: '방송 리스트 조회' })
+  @ApiSuccessResponse(SuccessStatus.OK(BroadcastListResponseDto), BroadcastListResponseDto)
+  @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
   async getAll() {
     const broadcasts = await this.broadcastService.getAll();
     return SuccessStatus.OK(BroadcastListResponseDto.from(broadcasts));
   }
 
   @Get('/:broadcastId/info')
+  @ApiTags(SwaggerTag.WATCH)
+  @ApiOperation({ summary: '방송 하단 정보 조회' })
+  @ApiSuccessResponse(SuccessStatus.OK(BroadcastInfoResponseDto), BroadcastInfoResponseDto)
+  @ApiErrorResponse(400, ErrorStatus.BROADCAST_NOT_FOUND)
+  @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
   async getBroadcastInfo(@Param('broadcastId') broadcastId: string) {
     const broadcast = await this.broadcastService.getBroadcastInfo(broadcastId);
 
@@ -27,6 +41,12 @@ export class BroadcastController {
   // TODO: 유저 기능 추가 후 유저의 방송 찾는 로직 구현 필요
   @Patch('/title')
   // @UseGuards(JwtAuthGuard)
+  @ApiTags(SwaggerTag.BROADCAST)
+  @ApiOperation({ summary: '방송 제목 수정' })
+  @ApiBody({ type: UpdateBroadcastTitleDto })
+  @ApiSuccessResponse(SuccessStatus.OK(null))
+  @ApiErrorResponse(400, ErrorStatus.BROADCAST_NOT_FOUND)
+  @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
   async updateTitle(
     // @Request() req,
     @Body() updateBroadcastTitleDto: UpdateBroadcastTitleDto,

--- a/apps/api/src/broadcast/dto/broadcast-info-response.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-info-response.dto.ts
@@ -1,12 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { FieldEnum } from '../../member/enum/field.enum';
 import { Broadcast } from '../broadcast.entity';
 
 export class BroadcastInfoResponseDto {
+  @ApiProperty({ example: '오늘 코딩 켠왕 간다' })
   title: string;
+
+  @ApiProperty({ example: 'J219' })
   camperId: string;
+
+  @ApiProperty({ example: 'WEB' })
   field: FieldEnum;
+
+  @ApiProperty({ example: 99 })
   viewers: number;
+
+  @ApiProperty({ example: 'profileImage 주소 src' })
   profileImage: string;
+
+  @ApiProperty({
+    example: {
+      github: 'https://github/~',
+      linkedin: 'https://linkedin/~',
+      email: 'huiseon37@gmail.com',
+      blog: 'https://tistory/~',
+    },
+  })
   contacts: {
     github: string;
     linkedin: string;

--- a/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
@@ -1,12 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { FieldEnum } from '../../member/enum/field.enum';
 import { Broadcast } from '../broadcast.entity';
 
 export class BroadcastListResponseDto {
+  @ApiProperty({ example: '73ebe906-0897-478d-b7c6-42f5ba7abc0a' })
   broadcastId: string;
+
+  @ApiProperty({ example: '오늘 코딩 켠왕 간다' })
   broadcastTitle: string;
+
+  @ApiProperty({ example: 'thunbnail 주소 src' })
   thumbnail: string;
+
+  @ApiProperty({ example: 'J219' })
   camperId: string;
+
+  @ApiProperty({ example: 'profile Image 주소 src' })
   profileImage: string;
+
+  @ApiProperty({ example: 'WEB' })
   field: FieldEnum;
 
   static from(broadcasts: Broadcast[]) {

--- a/apps/api/src/broadcast/dto/update-broadcast-title.request.dto.ts
+++ b/apps/api/src/broadcast/dto/update-broadcast-title.request.dto.ts
@@ -1,8 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString, MaxLength, MinLength } from 'class-validator';
 
 export class UpdateBroadcastTitleDto {
   @IsString()
   @MinLength(1, { message: '제목은 최소 1자 이상이어야 합니다.' })
   @MaxLength(255, { message: '제목 글자 수 제한을 초과했습니다.' })
+  @ApiProperty({ example: '오늘 코딩 켠왕 간다' })
   title: string;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #192 

## ✨ 구현 기능 명세
- 방송 리스트 조회, 방송 제목 수정, 방송 시청 하단 정보 조회 api에 스웨거 적용

## 🎁 PR Point
- dto가 원래 이렇게 더러워 지는것이 맞나요? 혹시 다른 방법으로 적용할 수 있다면 리뷰 부탁드립니다..
- 
![스크린샷 2024-11-19 오전 2 18 49](https://github.com/user-attachments/assets/8065fa47-7545-4298-a1a2-d6cfe603d952)

## 😭 어려웠던 점
- 없다!