### PR TITLE
[Fix] 로컬 클라이언트에서 요청 시 credential 설정

### DIFF
--- a/apps/client/src/hooks/useSocket.ts
+++ b/apps/client/src/hooks/useSocket.ts
@@ -7,7 +7,15 @@ export const useSocket = (url: string) => {
   const [isConnected, setIsConnected] = useState(false);
 
   useEffect(() => {
-    const socket = io(url);
+    const socket = io(url, {
+      withCredentials: true,
+      secure: true,
+      transports: ['websocket', 'polling'],
+      timeout: 10000,
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
+    });
     socketRef.current = socket;
 
     socket.on('connect', () => {

--- a/apps/client/src/services/axios.ts
+++ b/apps/client/src/services/axios.ts
@@ -5,6 +5,7 @@ const baseUrl = import.meta.env.VITE_API_SERVER_URL;
 const axiosInstance = axios.create({
   baseURL: baseUrl,
   headers: { 'Content-Type': 'application/json' },
+  withCredentials: true,
   timeout: 5000,
 });
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #198 

## ✨ 구현 기능 명세

- axios 인스턴스 생성 시 `withCredentials:true` 설정 추가
- useSocket에서 소켓 연결 시 설정 추가

## 🎁 PR Point

> Access to XMLHttpRequest at '미디어 서버로 요청 URI' from origin 'http://localhost:5173/' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

> GET [http://미디어서버주소/socket.io/?EIO=4&transport=polling&t=ttejo256](http://xn--2z1br4kbmw5mbqan3rcmg/socket.io/?EIO=4&transport=polling&t=ttejo256) net::ERR_FAILED 301 (Moved Permanently)

로컬 클라이언트에서 이런 CORS 관련 에러가 발생해서 소켓과 api 요청할 때 모두 `withCredentials:true` 설정을 추가해줬다. 그리고 소켓에 설정을 하는 김에 기본적으로 polling 방식이 아닌 websocket 방식을 사용하도록 명시해줬다.

### axios 인스턴스 생성

```typescript
const axiosInstance = axios.create({
  baseURL: baseUrl,
  headers: { 'Content-Type': 'application/json' },
  withCredentials: true,
  timeout: 5000,
});
```

### 소켓 연결

```typescript
const socket = io(url, {
  withCredentials: true,
  secure: true,
  transports: ['websocket', 'polling'],
  timeout: 10000,
  reconnection: true,
  reconnectionAttempts: 5,
  reconnectionDelay: 1000,
});
```

## 😭 어려웠던 점
