### PR TITLE
[Feat] 소켓 exception 에러 처리

### DIFF
--- a/apps/client/src/hooks/useSocket.ts
+++ b/apps/client/src/hooks/useSocket.ts
@@ -1,6 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
 
+interface ExceptionData {
+  status: number;
+  message: string;
+}
+
+interface ExceptionResponse {
+  event: string;
+  data: ExceptionData;
+}
+
 export const useSocket = (url: string) => {
   const socketRef = useRef<Socket | null>(null);
   const [socketError, setSocketError] = useState<Error | null>(null);
@@ -19,8 +29,9 @@ export const useSocket = (url: string) => {
       setSocketError(new Error(`Websocket 연결 실패: ${error}`));
     });
 
-    socket.on('exception', error => {
-      console.log(error);
+    socket.on('exception', (error: ExceptionResponse) => {
+      console.error(`socket exception Error: ${error.data.status}`);
+      setSocketError(new Error(error.data.message));
     });
 
     return () => {

--- a/apps/client/src/pages/Broadcast.tsx
+++ b/apps/client/src/pages/Broadcast.tsx
@@ -1,4 +1,5 @@
 import BroadcastTitle from '@/components/BroadcastTitle';
+import ErrorCharacter from '@/components/common/ErrorCharacter';
 import { useMediaControls } from '@/hooks/useMediaControls';
 import { useMediaStream } from '@/hooks/useMediaStream';
 import { useProducer } from '@/hooks/useProducer';
@@ -19,13 +20,11 @@ const socketUrl = import.meta.env.VITE_MEDIASERVER_URL;
 function Broadcast() {
   const { mediaStream, mediaStreamError, isMediastreamReady, videoRef } = useMediaStream();
   const { isAudioEnabled, isVideoEnabled, toggleAudio, toggleVideo } = useMediaControls(mediaStream);
-  const { socket, isConnected, socketError: _se } = useSocket(socketUrl);
-  const { roomId, roomError: _re } = useRoom(socket, isConnected);
-  const { transportInfo, device, transportError: _te } = useTransport({ socket, roomId, isProducer: true });
-
+  const { socket, isConnected, socketError } = useSocket(socketUrl);
+  const { roomId, roomError } = useRoom(socket, isConnected);
+  const { transportInfo, device, transportError } = useTransport({ socket, roomId, isProducer: true });
 
   const { transport, error: mediasoupError } = useProducer({
-
     socket,
     isMediastreamReady,
     mediaStream,
@@ -71,6 +70,14 @@ function Broadcast() {
   const handleBroadcastTitle = (newTitle: string) => {
     setTitle(newTitle);
   };
+
+  if (socketError || roomError || transportError) {
+    return (
+      <div className="flex h-screen justify-center items-center">
+        <ErrorCharacter size={300} message="방송 연결 중 에러가 발생했습니다. 관리자에게 문의하세요." />
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/client/src/pages/Live.tsx
+++ b/apps/client/src/pages/Live.tsx
@@ -1,3 +1,4 @@
+import ErrorCharacter from '@/components/common/ErrorCharacter';
 import LiveCamperInfo from '@/components/LiveCamperInfo';
 import { useConsumer } from '@/hooks/useConsumer';
 import { useSocket } from '@/hooks/useSocket';
@@ -10,12 +11,8 @@ const socketUrl = import.meta.env.VITE_MEDIASERVER_URL;
 
 export default function Live() {
   const { liveId } = useParams<{ liveId: string }>();
-  const { socket, isConnected, socketError: _se } = useSocket(socketUrl);
-  const {
-    transportInfo,
-    device,
-    transportError: _te,
-  } = useTransport({
+  const { socket, isConnected, socketError } = useSocket(socketUrl);
+  const { transportInfo, device, transportError } = useTransport({
     socket,
     roomId: liveId,
     isProducer: false,
@@ -54,17 +51,25 @@ export default function Live() {
       handleLeaveLive();
       window.removeEventListener('beforeunload', preventClose);
     };
-  }, [socket, liveId, transportInfo]);
+  }, []);
 
   return (
     <div className="fixed top-[88px] bottom-0 left-0 right-0 overflow-auto flex flex-row w-full gap-10">
-      <div className="flex flex-col basis-3/4 gap-4 w-7/12 h-full ml-8">
-        <LivePlayer mediaStream={mediaStream} />
-        <div className="flex-grow">
-          <LiveCamperInfo />
+      {socketError || transportError ? (
+        <div className="flex w-full h-full justify-center items-center">
+          <ErrorCharacter size={400} message="방송 연결 중 에러가 발생했습니다. 관리자에게 문의하세요" />
         </div>
-      </div>
-      <div className="bg-surface-alt basis-1/4">채팅</div>
+      ) : (
+        <>
+          <div className="flex flex-col basis-3/4 gap-4 w-7/12 h-full ml-8">
+            <LivePlayer mediaStream={mediaStream} />
+            <div className="flex-grow">
+              <LiveCamperInfo />
+            </div>
+          </div>
+          <div className="bg-surface-alt basis-1/4">채팅</div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #201 

## ✨ 구현 기능 명세

- exception 에러 발생 시 처리
- 에러 시 방송 송출/시청 페이지에서 에러 컴포넌트 보여주도록 수정
- Live에서 useEffect의 의존성 배열 때문에 socket이 disconnect되던 문제 수정

## 🎁 PR Point

### 방송 송출 중 소켓에서 exception 에러 발생할 때 나오는 화면

![image](https://github.com/user-attachments/assets/34b9af4c-7dee-4e82-87cb-472fce73fce9)

방송 시청 쪽에서도 에러 발생 시 다음과 같은 화면이 출력된다.

### Live에서 useEffect의 의존성 배열 때문에 socket이 disconnect되던 문제 수정

원래 아래의 코드와 같이 useEffect의 의존성 배열이 설정되어 있었다.

```typescript
const handleLeaveLive = () => {
  if (socket && liveId && transportInfo) {
    socket.emit('leaveBroadcast', { transportId: transportInfo.transportId, roomId: liveId });
  }

  socket?.disconnect();
  transport?.close();
};

// ...

useEffect(() => {
  window.addEventListener('beforeunload', preventClose);

  return () => {
    handleLeaveLive();
    window.removeEventListener('beforeunload', preventClose);
  };
}, [socket, liveId, transportInfo]);
```

그런데 이렇게 되어 있으니 useConsumer 훅이 실행되며 transportInfo 값이 바뀌어서 useEffect가 실행되게 된다. 즉, socket이 disconnect가 된다. 그래서 socket이 useConsumer가 실행되던 중에 disconnect되어버려서 createConsumer 이벤트가 발생하지 않게 된다.

이 문제는 의존성 배열에 불필요하게 `[socket, liveId, transportInfo]`가 설정되어 있어서 발생한 문제이므로 해당 의존성 배열을 빈 배열(`[]`)으로 만들어주었다.

## 😭 어려웠던 점
