### PR TITLE
[Chore] 커스텀 훅 의존성 체크 로직 추가 & 타입 정리

### DIFF
--- a/apps/client/src/hooks/useRoom.ts
+++ b/apps/client/src/hooks/useRoom.ts
@@ -1,4 +1,3 @@
-import { CreateRoomResponse } from '@/types/mediasoupTypes';
 import { useEffect, useState } from 'react';
 import { Socket } from 'socket.io-client';
 
@@ -7,10 +6,13 @@ export const useRoom = (socket: Socket | null, isConnected: boolean) => {
   const [roomError, setRoomError] = useState<Error | null>(null);
 
   const getRooomId = async () => {
-    if (!socket) return;
+    if (!socket) {
+      setRoomError(new Error('getRoomId Error: socket이 존재하지 않습니다.'));
+      return;
+    }
     try {
-      const { roomId } = await new Promise<CreateRoomResponse>(resolve => {
-        socket.emit('createRoom', (response: CreateRoomResponse) => {
+      const { roomId } = await new Promise<{ roomId: string }>(resolve => {
+        socket.emit('createRoom', (response: { roomId: string }) => {
           resolve(response);
         });
       });

--- a/apps/client/src/lib/utils.ts
+++ b/apps/client/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const checkDependencies = (functionName: string, dependencies: { [key: string]: any }) => {
+  const missing = dependencies.keys(dependencies).filter((key: string) => !dependencies[key]);
+
+  if (missing.length === 0) return null;
+  return new Error(`${functionName} Error: ${missing.join(',')}이(가) 없습니다.`);
+};

--- a/apps/client/src/pages/Broadcast.tsx
+++ b/apps/client/src/pages/Broadcast.tsx
@@ -23,9 +23,7 @@ function Broadcast() {
   const { roomId, roomError: _re } = useRoom(socket, isConnected);
   const { transportInfo, device, transportError: _te } = useTransport({ socket, roomId, isProducer: true });
 
-
   const { transport, error: mediasoupError } = useProducer({
-
     socket,
     isMediastreamReady,
     mediaStream,
@@ -61,7 +59,11 @@ function Broadcast() {
 
   useEffect(() => {
     window.addEventListener('beforeunload', stopBroadcast);
-  }, [socket]);
+
+    return () => {
+      window.removeEventListener('beforeunload', stopBroadcast);
+    };
+  }, []);
 
   const handleCheckout = () => {
     stopBroadcast();

--- a/apps/client/src/types/mediasoupTypes.ts
+++ b/apps/client/src/types/mediasoupTypes.ts
@@ -1,40 +1,5 @@
 // types/broadcast.ts
-import { MediaKind, RtpCapabilities } from 'mediasoup-client/lib/RtpParameters';
-import { Device, Transport, DtlsParameters, IceCandidate, IceParameters } from 'mediasoup-client/lib/types';
-import { Socket } from 'socket.io-client';
-
-export interface useMediasoupProps {
-  socketUrl: string;
-  liveId: string | undefined;
-  mediastream: MediaStream | null;
-  isMediastreamReady: boolean;
-  isProducer: boolean;
-}
-
-export interface useProducerProps {
-  socketUrl: string;
-  mediastream: MediaStream | null;
-  isMediastreamReady: boolean;
-}
-
-export interface useConsumerProps {
-  socketUrl: string;
-  liveId: string | undefined;
-}
-
-export interface useTransportProps {
-  socket: Socket | null;
-  roomId: string | undefined;
-  isProducer: boolean;
-}
-
-export interface RtpCapabilitiesResponse {
-  rtpCapabilities: RtpCapabilities;
-}
-
-export interface CreateRoomResponse {
-  roomId: string;
-}
+import { DtlsParameters, IceCandidate, IceParameters } from 'mediasoup-client/lib/types';
 
 export interface TransportInfo {
   transportId: string;
@@ -42,45 +7,6 @@ export interface TransportInfo {
   iceParameters: IceParameters;
   iceCandidates: IceCandidate[];
   dtlsParameters: DtlsParameters;
-}
-
-export interface ConnectTransportResponse {
-  connected: boolean;
-  isProducer: boolean;
-}
-
-export interface CreateConsumer {
-  consumerId: string;
-  producerId: string;
-  kind: MediaKind;
-  rtpParameters: any;
-}
-
-export interface CreateConsumerResponse {
-  consumers: CreateConsumer[];
-}
-
-export interface MediasoupDeviceState {
-  device: Device | null;
-  deviceError: Error | null;
-}
-
-export interface MediasoupRoomState {
-  roomId: string;
-  roomError: Error | null;
-}
-
-export interface MediasoupTransportState {
-  transport: Transport | null;
-  transportError: Error | null;
-}
-
-export interface MediasoupDeviceActions {
-  createDevice: () => Promise<void>;
-}
-
-export interface MediasoupTransportActions {
-  createTransport: () => Promise<void>;
 }
 
 export interface ConnectTransportResponse {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #204 

## ✨ 구현 기능 명세

- 커스텀 훅 의존성을 체크하기 위한 유틸 함수 작성
- 커스텀 훅 타입 정리

## 🎁 PR Point

### 커스텀 훅 의존성을 체크하기 위한 유틸 함수

- 만든 이유
Live.tsx의 useEffect에서 의존성 배열에 불필요한 값을 넣어서 소켓이 Consumer를 다 만들기 전에 disconnect되는 문제가 발생했다. 그러니까 useConsumer 훅이 실행되던 중에 socket.disconnect() 코드가 실행되며 socket이 없어서 createConsumer 이벤트가 발생하지 못했던 것이다.

이 문제의 원인을 찾을 때 각 커스텀 훅의 의존성이 없을 때 setError를 하지 않고, 그냥 return만 해서 문제의 원인을 찾기 어려웠다. 그렇기에 각 커스텀 훅의 의존성이 없을 때도 에러를 세팅하도록 수정하려고 했다. 그리고 이러한 작업은 반복적으로 이루어지기에 별도의 유틸 함수로 만들었다.

```typescript
export const checkDependencies = (functionName: string, dependencies: { [key: string]: any }) => {
  const missing = dependencies.keys(dependencies).filter((key: string) => !dependencies[key]);

  if (missing.length === 0) return null;
  return new Error(`${functionName} Error: ${missing.join(',')}이(가) 없습니다.`);
};
```

### 커스텀 훅 타입 정리

src/types/mediasoupTypes.ts에 mediasoup 연결 및 스트림 전송에 사용되는 커스텀 훅(`useRoom`, `useTransport`, `useProducer`, `useConsumer`)에서 사용되는 타입들이 정의되어 있었다. 하지만 별도의 파일로 분리되어 있으니 보기 불편하다고 생각하여 각 커스텀 훅에서만 사용하는 타입들은 해당 커스텀 훅 파일로 옮기고, 공통적으로 사용되는 타입들만 mediasoupTypes.ts에 남겼다.

## 😭 어려웠던 점
