### PR TITLE
[Feat] 방송 제목 수정 요청 구현

### DIFF
--- a/apps/client/src/components/BroadcastTitle.tsx
+++ b/apps/client/src/components/BroadcastTitle.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { Button } from './ui/button';
+import axiosInstance from '@/services/axios';
 
 interface Inputs {
   title: string;
@@ -17,6 +18,7 @@ function BroadcastTitle({ currentTitle, onTitleChange }: BroadcastTitleProps) {
     handleSubmit,
     formState: { errors },
   } = useForm<Inputs>();
+
   const [isEditing, setIsEditing] = useState(false);
 
   const handleEditTitle = () => {
@@ -24,7 +26,14 @@ function BroadcastTitle({ currentTitle, onTitleChange }: BroadcastTitleProps) {
   };
 
   const onSubmit: SubmitHandler<Inputs> = data => {
-    onTitleChange(data.title);
+    // TODO: 요청 헤더에 Authorization 설정
+    axiosInstance.patch('/v1/broadcasts/title', { title: data.title }).then(response => {
+      if (!response.data.success) {
+        alert('제목 변경에 실패했습니다!');
+      } else {
+        onTitleChange(data.title);
+      }
+    });
     setIsEditing(false);
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #207 

## ✨ 구현 기능 명세

- 방송 제목 수정 요청 구현

## 🎁 PR Point

```typescript
const onSubmit: SubmitHandler<Inputs> = data => {
  // TODO: 요청 헤더에 Authorization 설정
  axiosInstance.patch('/v1/broadcasts/title', { title: data.title }).then(response => {
    if (!response.data.success) {
      alert('제목 변경에 실패했습니다!');
    } else {
      onTitleChange(data.title);
    }
  });
  setIsEditing(false);
};
```

방송 제목 수정 폼에서 "수정" 버튼을 누르면 해당 로직이 실행된다. 요청을 보낼 때 헤더에 액세스 토큰을 넣어서 보내야 하는데, 아직 로그인 기능이 없어서 이것은 TODO로 남겨놨다.

## 😭 어려웠던 점

useAPI 훅을 이용하려고 했는데, 이 훅은 동적으로 변경되는 데이터를 반영할 수가 없다는 문제점이 있다. 그래서 useAPI를 사용하지 않고, 직접 요청을 보내는 형식으로 구현을 했다.

만약 useAPI를 사용한다면 수정을 조금 해야한다. 현재는 useAPI가 실행되면 api 요청을 보내고 응답을 받은 데이터를 리턴하고 있는데, 이런 경우에는 컴포넌트 내에서 동적으로 변경되는 데이터를 요청에 담아서 보낼 수 없다. 그렇기에 동적인 데이터도 body에 넣어서 요청할 수 있도록 변경한다면 useAPI가 데이터를 리턴하지 않고, api 요청을 보내는 fetchData 함수를 리턴하도록 하면 될 것 같은데, 이 경우에는 useAPI를 사용하는 이유가 별로 없지 않나?하는 생각이 들었다. 데이터 fetch 시 로딩과 에러 처리를 할 수 있는 tanstack query 사용을 고려해봐야할 것 같다.