### PR TITLE
[Fix] 방송 리스트 요청 안함 & 송출 에러 처리 해결

### DIFF
--- a/apps/client/src/components/LiveList.tsx
+++ b/apps/client/src/components/LiveList.tsx
@@ -1,20 +1,23 @@
-import { LiveInfo } from '@/types/liveTypes';
+import { LivePreviewInfo } from '@/types/homeTypes';
 import LiveCard from './LiveCard';
 
-function LiveList({ liveList }: { liveList: LiveInfo[] | null }) {
+function LiveList({ liveList }: { liveList: LivePreviewInfo[] }) {
   return (
     <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-[clamp(40px,2vw,60px)] p-15 w-[95%] max-w-[1920px] place-items-center">
       {liveList &&
-        liveList.map(liveInfo => (
-          <LiveCard
-            key={liveInfo.broadcastId}
-            liveId={liveInfo.broadcastId}
-            title={liveInfo.broadcastTitle}
-            userId={liveInfo.camperId}
-            profileUrl={liveInfo.profileImage}
-            thumbnailUrl={liveInfo.thumbnail}
-          />
-        ))}
+        liveList.map(livePreviewInfo => {
+          const { broadcastId, broadcastTitle, camperId, profileImage, thumbnail } = livePreviewInfo;
+          return (
+            <LiveCard
+              key={broadcastId}
+              liveId={broadcastId}
+              title={broadcastTitle}
+              userId={camperId}
+              profileUrl={profileImage}
+              thumbnailUrl={thumbnail}
+            />
+          );
+        })}
     </div>
   );
 }

--- a/apps/client/src/hooks/useConsumer.ts
+++ b/apps/client/src/hooks/useConsumer.ts
@@ -48,7 +48,9 @@ export const useConsumer = ({ socket, device, roomId, transportInfo, isConnected
       setError(dependencyError);
       return;
     }
-    console.log('connectTransport 함수 실행');
+
+    setError(null);
+
     try {
       const newTransport = device.createRecvTransport({
         id: transportInfo.transportId,
@@ -101,6 +103,8 @@ export const useConsumer = ({ socket, device, roomId, transportInfo, isConnected
       setError(dependencyError);
       return;
     }
+
+    setError(null);
 
     try {
       socket.emit(

--- a/apps/client/src/hooks/useMediaControls.ts
+++ b/apps/client/src/hooks/useMediaControls.ts
@@ -30,7 +30,6 @@ export const useMediaControls = (mediaStream: MediaStream | null): MediaControls
 
   const toggleVideo = () => {
     if (!mediaStream) return;
-    console.log('toggleVIdeo');
     const videoTrack = mediaStream.getVideoTracks()[0];
     if (videoTrack) {
       videoTrack.enabled = !videoTrack.enabled;
@@ -40,7 +39,6 @@ export const useMediaControls = (mediaStream: MediaStream | null): MediaControls
 
   const toggleAudio = () => {
     if (!mediaStream) return;
-    console.log('toggleAudio');
     const audioTrack = mediaStream.getAudioTracks()[0];
     if (audioTrack) {
       audioTrack.enabled = !audioTrack.enabled;

--- a/apps/client/src/hooks/useMediaStream.ts
+++ b/apps/client/src/hooks/useMediaStream.ts
@@ -3,7 +3,6 @@ import { useEffect, useRef, useState } from 'react';
 export const useMediaStream = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
-  // const [mediaStream, setIsMediastream] = useState<MediaStream | null>(null);
   const [mediaStreamError, setMediaStreamError] = useState<Error | null>(null);
   const [isMediastreamReady, setIsMediastreamReady] = useState(false);
 

--- a/apps/client/src/hooks/useProducer.ts
+++ b/apps/client/src/hooks/useProducer.ts
@@ -38,6 +38,8 @@ export const useProducer = ({
       return;
     }
 
+    setError(null);
+
     try {
       const newTransport = device.createSendTransport({
         id: transportInfo.transportId,
@@ -89,6 +91,8 @@ export const useProducer = ({
       setError(dependencyError);
       return;
     }
+
+    setError(null);
 
     try {
       await new Promise<string>(resolve => {

--- a/apps/client/src/hooks/useRoom.ts
+++ b/apps/client/src/hooks/useRoom.ts
@@ -10,6 +10,9 @@ export const useRoom = (socket: Socket | null, isConnected: boolean) => {
       setRoomError(new Error('getRoomId Error: socket이 존재하지 않습니다.'));
       return;
     }
+
+    setRoomError(null);
+
     try {
       const { roomId } = await new Promise<{ roomId: string }>(resolve => {
         socket.emit('createRoom', (response: { roomId: string }) => {

--- a/apps/client/src/hooks/useSocket.ts
+++ b/apps/client/src/hooks/useSocket.ts
@@ -30,11 +30,18 @@ export const useSocket = (url: string) => {
 
     socket.on('connect', () => {
       setIsConnected(true);
+      setSocketError(null);
       console.log('소켓 연결');
     });
 
     socket.on('connect_error', error => {
+      setIsConnected(false);
       setSocketError(new Error(`Websocket 연결 실패: ${error}`));
+    });
+
+    socket.on('disconnect', reason => {
+      setIsConnected(false);
+      setSocketError(new Error(`소켓 연결이 끊어졌습니다: ${reason}`));
     });
 
     socket.on('exception', (error: ExceptionResponse) => {

--- a/apps/client/src/hooks/useSocket.ts
+++ b/apps/client/src/hooks/useSocket.ts
@@ -21,9 +21,9 @@ export const useSocket = (url: string) => {
       withCredentials: true,
       secure: true,
       transports: ['websocket', 'polling'],
-      timeout: 10000,
-      reconnection: true,
-      reconnectionAttempts: 5,
+      timeout: 10000, // 10초 동안 응답 못 받으면 연결 끊음
+      reconnection: true, // 재연결 시도 활성화
+      reconnectionAttempts: 5, // 최대 재연결 시도 횟수
       reconnectionDelay: 1000,
     });
     socketRef.current = socket;

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -2,9 +2,10 @@ import LiveList from '@/components/LiveList';
 import LoadingCharacter from '@components/common/LoadingCharacter';
 import ErrorCharacter from '@components/common/ErrorCharacter';
 import { useAPI } from '@/hooks/useAPI';
+import { LivePreviewInfo } from '@/types/homeTypes';
 
 export default function Home() {
-  const { data: liveList, isLoading, error } = useAPI({ url: '/v1/broadcasts' });
+  const { data: liveList, isLoading, error } = useAPI<LivePreviewInfo[]>({ url: '/v1/broadcasts' });
 
   return (
     <div className="flex justify-center w-full h-[calc(100vh-88px)]">
@@ -16,8 +17,10 @@ export default function Home() {
         <div className="flex justify-center items-center flex-1">
           <LoadingCharacter />
         </div>
-      ) : (
+      ) : liveList ? (
         <LiveList liveList={liveList} />
+      ) : (
+        <div>방송 중인 캠퍼가 없습니다.</div>
       )}
     </div>
   );

--- a/apps/client/src/types/homeTypes.ts
+++ b/apps/client/src/types/homeTypes.ts
@@ -1,0 +1,8 @@
+export interface LivePreviewInfo {
+  broadcastId: string;
+  broadcastTitle: string;
+  camperId: string;
+  profileImage: string;
+  thumbnail: string;
+  field: 'WEB' | 'AND' | 'IOS';
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #209 

## ✨ 구현 기능 명세

- Home 페이지에서 방송 리스트 요청을 안 보내는 에러 해결
- 커스텀 훅에서 의존성 문제 없을 시 에러 초기화하도록 수정
- socket disconnect 시 에러 세팅

## 🎁 PR Point

### 1. 방송 리스트 출력 안 되는 문제

- 문제 상황
    
    Home 페이지에 들어가면 방송 리스트를 갖고 와서 보여주어야 하는데, 방송 리스트 요청이 보내지지 않고 있다.
    
- **원인**
    
    Home 페이지의 방송 목록을 띄우기 위해 방송 미리보기 하나에 사용되는 정보들의 타입을 `LivInfo`라고 해놓고, Live 페이지의 방송 상세 정보 컴포넌트에서 사용되는 데이터들의 타입을 `LiveInfo`라고 지어놨다. 그런데 이 부분을 Live 쪽을 수정하며 타입을 잘못 바꿔버렸다.
    
- **해결**
    
    방송 미리보기에 필요한 정보들의 타입을 `LivePreviewInfo`로 이름을 바꿨다. 
    
- **비슷한 문제가 생기지 않도록 대처 방안**
    - 타입 import를 잘못하거나 잘못 수정하는 경우를 방지하기 위해 하나의 컴포넌트에서만 사용되는 타입은 해당 컴포넌트 파일 안에 작성하기로 한다.
    - 여러 컴포넌트에서 사용되는 경우에는 이름을 분명하게 구별되도록 지어서 헷갈리지 않게 한다.

### 2. 방송 송출 에러 처리

- **문제 상황**
    
    정상적으로 카메라가 켜지고, 방송 연결이 되는데 에러 화면이 뜨는 경우가 발생.
    
- **원인**
    
    각 커스텀 훅의 함수들마다 실행하는데 필요한 데이터들이 없으면 에러를 세팅하는데, 커스텀 훅은 순차적으로 일어나지 않는 동작이다보니 초기 어느 시점에는 필요한 데이터가 없을 수 있다. 이때 에러를 세팅하도록 이슈 #204에서 설정해놨는데, 이후에 데이터가 세팅된 후에도 에러가 초기화되지 않고 남아있어서 문제가 발생한 것으로 보인다.
    
    예를 들자면, useRoom → useTransport → useProducer가 순차적으로 이루어져야 하는데, useTransport가 실행되고 있는 시점에 useProducer도 실행되고 있다. 그런데, 아직 useTransport가 다 실행되지 않아서 useProducer의 함수들은 필요한 데이터(의존성)이 없다고 판단하여 Error를 세팅해버리는 것이다. useTransport가 정상적으로 실행 완료된 시점에는 useProducer를 정상적으로 실행할 수 있으므로 세팅했던 에러들이 없어져야 하는데, 이 에러 초기화를 넣지 않아서 문제인 것이다.
    
    ```tsx
    //useProducer.tsx 내부 함수
    const createTransport = async (socket: Socket, device: Device, roomId: string, transportInfo: TransportInfo) => {
    	// 선행되어야 하는 커스텀 훅들을 실행하며 세팅된 데이터들(의존성)
    	// 커스텀 훅은 순차적인 실행이 보장되지 않으므로 초반에는 필요한 데이터가 없을 수 있다.
    	// 그런 경우 에러가 세팅된다. 
    	// 그런데 나중에 필요한 데이터가 모두 세팅된 이후에도 에러가 초기화되지 않아서 문제
      if (!socket || !device || !roomId || !transportInfo) {
        const dependencyError = checkDependencies('createTransport', { socket, device, roomId, transportInfo });
        setError(dependencyError);
        return;
      }
    
      // ...
    };
    ```
    
- **해결**
    
    만약 의존성 문제가 없다면 error를 초기화해주는 코드 추가.
    
- **추후 생각해볼 수 있는 개선 방안**
    
    현재 여러 개의 커스텀 훅으로 나뉜 구조는 동기적으로 실행되어야 하는 코드를 실행하기에 그닥 좋지 않은 구조라고 느꼈다. 
    
    지금 구조의 단점은: 
    
    - 각 커스텀 훅 간의 의존성 관리가 복잡하다
    - 의존성 관리가 복잡하여 에러 처리가 많이 들어가게 되었다.
    - 코드가 더 길어졌다.
    
    물론 개별 커스텀 훅으로 구성했을 때의 장점도 있긴 하다. 
    
    - 관심사 분리가 명확하다. (룸 생성, 미디어 트랜스포트 설정, 프로듀서/컨슈머 생성)
    - 코드 재사용성이 높다.
    - 각 단계별 테스트가 용이하다.
    
    그렇기만 이 장점보다 단점이 더 크다고 생각되어서 리팩토링을 해야겠다는 생각은 든다.

## 😭 어려웠던 점
