### PR TITLE
[Feat] 소켓 연결 해제 이벤트 등록

### DIFF
--- a/apps/media/src/attendance/attendance.module.ts
+++ b/apps/media/src/attendance/attendance.module.ts
@@ -1,4 +1,0 @@
-import { Module } from '@nestjs/common';
-
-@Module({})
-export class AttendanceModule {}

--- a/apps/media/src/member/member.module.ts
+++ b/apps/media/src/member/member.module.ts
@@ -1,4 +1,0 @@
-import { Module } from '@nestjs/common';
-
-@Module({})
-export class MemberModule {}

--- a/apps/media/src/sfu/services/client.service.ts
+++ b/apps/media/src/sfu/services/client.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+
+interface IClientTransport {
+  transportId: string;
+  roomId: string;
+}
+
+@Injectable()
+export class ClientService {
+  private clientRoom = new Map<string, string>();
+  private clientTransport = new Map<string, IClientTransport>();
+
+  addClientToRoom(clientId: string, roomId: string) {
+    this.clientRoom.set(clientId, roomId);
+  }
+  addClientTransport(clientId: string, transportId: string, roomId: string) {
+    this.clientTransport.set(clientId, { transportId, roomId });
+  }
+
+  hasRoom(clientId: string) {
+    return this.clientRoom.has(clientId);
+  }
+
+  hasTransport(clientId: string) {
+    return this.clientTransport.has(clientId);
+  }
+
+  getClientRoom(clientId: string) {
+    return this.clientRoom.get(clientId);
+  }
+
+  getClientTransport(clientId: string) {
+    return this.clientTransport.get(clientId);
+  }
+
+  removeClient(clientId: string) {
+    this.clientRoom.delete(clientId);
+    this.clientTransport.delete(clientId);
+  }
+}

--- a/apps/media/src/sfu/services/transport.service.ts
+++ b/apps/media/src/sfu/services/transport.service.ts
@@ -96,6 +96,9 @@ export class TransportService {
     transport.on('routerclose', () => {
       this.handleTransportClose(transport, roomId);
     });
+    transport.observer.on('close', () => {
+      this.handleTransportClose(transport, roomId);
+    });
   }
 
   private handleTransportClose(transport: mediasoup.types.Transport, roomId: string) {

--- a/apps/media/src/sfu/sfu.module.ts
+++ b/apps/media/src/sfu/sfu.module.ts
@@ -8,6 +8,7 @@ import { TransportService } from './services/transport.service';
 import { ProducerService } from './services/producer.service';
 import { ConsumerService } from './services/consumer.service';
 import { BroadcastModule } from '../broadcast/broadcast.module';
+import { ClientService } from './services/client.service';
 import { RecordService } from './services/record.service';
 
 @Module({
@@ -21,6 +22,7 @@ import { RecordService } from './services/record.service';
     ProducerService,
     ConsumerService,
     RecordService,
+    ClientService,
   ],
 })
 export class SfuModule {}

--- a/apps/media/src/sfu/sfu.service.ts
+++ b/apps/media/src/sfu/sfu.service.ts
@@ -11,6 +11,7 @@ import { CreateProducerDto } from './dto/create-producer.dto';
 import { CreateConsumerDto } from './dto/create-consumer.dto';
 import { BroadcastService } from '../broadcast/broadcast.service';
 import { CreateBroadcastDto } from '../broadcast/dto/createBroadcast.dto';
+import { ClientService } from './services/client.service';
 import { RecordService } from './services/record.service';
 
 @Injectable()
@@ -22,13 +23,15 @@ export class SfuService {
     private readonly consumerService: ConsumerService,
     private readonly broadcasterService: BroadcastService,
     private readonly recordService: RecordService,
+    private readonly clientService: ClientService,
     private readonly configService: ConfigService,
   ) {}
 
-  async createRoom() {
+  async createRoom(clientId: string) {
     const room = await this.roomService.createRoom();
     const thumbnail = `${this.configService.get('RECORD_SERVER_URL')}/images/${room.id}`;
     await this.broadcasterService.createBroadcast(CreateBroadcastDto.of(room.id, 'J000님의 방송', thumbnail, null));
+    this.clientService.addClientToRoom(clientId, room.id);
     return room;
   }
 
@@ -56,7 +59,7 @@ export class SfuService {
     return producer;
   }
 
-  async createConsumers(params: CreateConsumerDto) {
+  async createConsumers(params: CreateConsumerDto, clientId: string) {
     const { roomId, transportId } = params;
     const room = this.roomService.getRoom(roomId);
     const producerTransport = this.transportService.getProducerTransport(roomId);
@@ -65,6 +68,7 @@ export class SfuService {
     const consumerTransport = this.transportService.getTransport(roomId, transportId);
     const consumers = await this.consumerService.createConsumers(consumerTransport, producers, room.rtpCapabilities);
     await this.broadcasterService.incrementViewers(roomId);
+    this.clientService.addClientTransport(clientId, consumerTransport.id, roomId);
     return consumers.map(consumer => {
       return {
         consumerId: consumer.id,
@@ -75,8 +79,8 @@ export class SfuService {
     });
   }
 
-  stopBroadcast(roomId: string) {
-    this.roomService.deleteRoom(roomId);
+  async stopBroadcast(roomId: string) {
+    await this.roomService.deleteRoom(roomId);
   }
 
   async leaveBroadcast(roomId: string, transportId: string) {
@@ -91,5 +95,16 @@ export class SfuService {
       }
     }
     return true;
+  }
+
+  async disconnectClient(clientId: string) {
+    if (this.clientService.hasRoom(clientId)) {
+      const roomId = this.clientService.getClientRoom(clientId);
+      await this.stopBroadcast(roomId);
+    }
+    if (this.clientService.hasTransport(clientId)) {
+      const data = this.clientService.getClientTransport(clientId);
+      await this.leaveBroadcast(data.roomId, data.transportId);
+    }
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #215

## ✨ 구현 기능 명세
- 소켓 연결이 해제되면 자동으로 리소스 정리
- ClientService를 만들어서 socketId 별로 생성한 리소스 저장
- socket 연결이 끊기면, ClientService에서 해당 socket으로 생성된 리소스를 찾아서 모두 정리
- 사용하지 않는 디렉토리들 삭제

## 🎁 PR Point
이제 클라이언트에서 연결 해제에 대한 이벤트를 호출하지 않고, 그냥 소켓 연결이 끊기면 모든 리소스가 정리되게 했습니다.

## 😭 어려웠던 점
