### PR TITLE
[Feat] 썸네일 db 저장 로직 구현

### DIFF
--- a/.github/workflows/media-deploy.yml
+++ b/.github/workflows/media-deploy.yml
@@ -19,6 +19,7 @@ jobs:
       ANNOUNCED_IP: ${{ secrets.ANNOUNCED_IP }}
       API_SERVER_URL: ${{ secrets.API_SERVER_URL }}
       HTTP_TIMEOUT: ${{ secrets.HTTP_TIMEOUT }}
+      RECORD_SERVER_URL: ${{secrets.RECORD_SERVER_URL}}
 
     steps:
       - name: Checkout code
@@ -85,6 +86,7 @@ jobs:
               -e DB_NAME=${{ secrets.DB_NAME }} \
               -e API_SERVER_URL=${{ secrets.API_SERVER_URL }} \
               -e HTTP_TIMEOUT=${{ secrets.HTTP_TIMEOUT }} \
+              -e RECORD_SERVER_URL=${{secrets.RECORD_SERVER_URL}} \
               ${{ secrets.NCLOUD_REGISTRY_URL }}/media-camon:latest
             sudo docker image prune -f
 

--- a/apps/api/src/broadcast/broadcast.service.ts
+++ b/apps/api/src/broadcast/broadcast.service.ts
@@ -55,10 +55,12 @@ export class BroadcastService {
     await this.broadcastRepository.update(broadcast.id, broadcast);
   }
 
-  async createBroadcast({ id, title }: CreateBroadcastDto): Promise<Broadcast> {
+  async createBroadcast({ id, title, thumbnail }: CreateBroadcastDto): Promise<Broadcast> {
     const broadcast = this.broadcastRepository.create({
       id,
       title,
+      thumbnail,
+      startTime: new Date(),
       member: null,
     });
 

--- a/apps/api/src/broadcast/dto/createBroadcast.dto.ts
+++ b/apps/api/src/broadcast/dto/createBroadcast.dto.ts
@@ -1,5 +1,6 @@
 export class CreateBroadcastDto {
   id: string;
   title: string; // 방송 제목
+  thumbnail: string;
   memberId: number; // 토큰을 통해 뽑아오면 됌
 }

--- a/apps/media/.env.example
+++ b/apps/media/.env.example
@@ -11,3 +11,4 @@ REDIS_MEDIA=
 # Settings for connecting to the api server
 API_SERVER_URL=
 HTTP_TIMEOUT=
+RECORD_SERVER_URL=

--- a/apps/media/src/broadcast/dto/createBroadcast.dto.ts
+++ b/apps/media/src/broadcast/dto/createBroadcast.dto.ts
@@ -1,12 +1,14 @@
 export class CreateBroadcastDto {
   id: string;
   title: string; // 방송 제목
+  thumbnail: string;
   memberId: number; // 토큰을 통해 뽑기
 
-  static of(id: string, title: string, memberId: number): CreateBroadcastDto {
+  static of(id: string, title: string, thumbnail: string, memberId: number) {
     const createBroadcastDto = new CreateBroadcastDto();
     createBroadcastDto.id = id;
     createBroadcastDto.title = title;
+    createBroadcastDto.thumbnail = thumbnail;
     createBroadcastDto.memberId = memberId;
     return createBroadcastDto;
   }

--- a/apps/media/src/sfu/services/record.service.ts
+++ b/apps/media/src/sfu/services/record.service.ts
@@ -1,10 +1,11 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import * as mediasoup from 'mediasoup';
 
 @Injectable()
 export class RecordService {
-  constructor(private readonly httpservice: HttpService) {}
+  constructor(private readonly httpservice: HttpService, private readonly configService: ConfigService) {}
 
   async sendStream(room: mediasoup.types.Router, producer: mediasoup.types.Producer) {
     if (producer.kind === 'audio') return;
@@ -33,7 +34,7 @@ export class RecordService {
     }, 1000);
 
     const { port } = await this.httpservice
-      .get('http://localhost:3003/availablePort')
+      .get(`${this.configService.get('RECORD_SERVER_URL')}/availablePort`)
       .toPromise()
       .then(({ data }) => data);
 
@@ -43,7 +44,7 @@ export class RecordService {
     });
 
     await this.httpservice
-      .post('http://localhost:3003/send', {
+      .post(`${this.configService.get('RECORD_SERVER_URL')}/send`, {
         roomId: room.id,
         port,
       })

--- a/apps/media/src/sfu/sfu.service.ts
+++ b/apps/media/src/sfu/sfu.service.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { Injectable } from '@nestjs/common';
 import * as mediasoup from 'mediasoup';
 import { ConnectTransportDto } from './dto/transport-params.interface';
@@ -21,11 +22,13 @@ export class SfuService {
     private readonly consumerService: ConsumerService,
     private readonly broadcasterService: BroadcastService,
     private readonly recordService: RecordService,
+    private readonly configService: ConfigService,
   ) {}
 
   async createRoom() {
     const room = await this.roomService.createRoom();
-    await this.broadcasterService.createBroadcast(CreateBroadcastDto.of(room.id, 'title', null));
+    const thumbnail = `${this.configService.get('RECORD_SERVER_URL')}/images/${room.id}`;
+    await this.broadcasterService.createBroadcast(CreateBroadcastDto.of(room.id, 'J000님의 방송', thumbnail, null));
     return room;
   }
 

--- a/apps/record/src/index.ts
+++ b/apps/record/src/index.ts
@@ -27,7 +27,7 @@ app.get('/availablePort', (req, res) => {
 
 app.get('/images/:roomId', (req, res) => {
   const { roomId } = req.params;
-  const thumbnailPath = path.join(__dirname, 'thumbnail', `${roomId}.jpg`);
+  const thumbnailPath = path.join(__dirname, '../thumbnail', `${roomId}.jpg`);
   fs.access(thumbnailPath, fs.constants.F_OK, err => {
     if (err) {
       console.error(`Thumbnail not found for roomId: ${roomId}`);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #216 

## ✨ 구현 기능 명세
- 썸네일 url db에 저장

## 🎁 PR Point
- 원래 api서버에서 바로 저장한다고 했었는데 현재 구현되어있는 로직을 보니 api서버에서는 값을 받아서 저장만 하고 있고, media 서버에서 값을 만들어 넘겨주는 로직이길래 thumbnail 주소를 media서버에서 생성한 후 api서버에 요청하여 값을 넣어주는 방식으로 구현했습니다.
- 방송 제목 기존 기획대로 J000님의 방송으로 default값 변경하였습니다. member 추가하면 camperId 넣으면 될 것 같아요.
- recordService로 port 요청과 ffmpeg 실행 요청 보내는 url 환경변수로 넣어서 처리해주도록 변경하였습니다. 추후 Record Client 만들어야 할 것 같아요.
- 환경변수가 수정되어 git actions 스크립트도 변경되었습니다!

<img width="727" alt="스크린샷 2024-11-20 오후 9 37 58" src="https://github.com/user-attachments/assets/2704553b-f894-4c4d-9620-6e66561acf28">

## 😭 어려웠던 점
- 없습니다!