### PR TITLE
:bug: [Fix]: unhandled rejection 문제 해결

### DIFF
--- a/apps/media/src/common/filter/webSocketException.filter.ts
+++ b/apps/media/src/common/filter/webSocketException.filter.ts
@@ -1,10 +1,12 @@
-import { Catch, ArgumentsHost } from '@nestjs/common';
+import { Catch, ArgumentsHost, Logger } from '@nestjs/common';
 import { BaseWsExceptionFilter, WsException } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
 
 @Catch(WsException)
 export class WebSocketExceptionFilter extends BaseWsExceptionFilter {
+  private readonly logger = new Logger(WebSocketExceptionFilter.name);
   catch(exception: WsException, host: ArgumentsHost) {
+    this.logger.error(exception);
     const client = host.switchToWs().getClient<Socket>();
     const event = host.switchToWs().getPattern();
 
@@ -22,7 +24,6 @@ export class WebSocketExceptionFilter extends BaseWsExceptionFilter {
         code: error.code || 500,
       },
     };
-
     client.emit('exception', wsResponse);
   }
 }

--- a/apps/media/src/main.ts
+++ b/apps/media/src/main.ts
@@ -17,3 +17,11 @@ async function bootstrap() {
   await app.listen(port);
 }
 bootstrap();
+
+process.on('uncaughtException', error => {
+  console.error('Uncaught Exception:', error);
+});
+
+process.on('unhandledRejection', reason => {
+  console.error('Unhandled Rejection:', reason);
+});


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #218

## ✨ 구현 기능 명세
- 예상치 못한 예외로 서버가 종료되는 이슈 해결

## 🎁 PR Point
- apiClient에서 httpService로 요청을 보내고 예외가 발생하면 해당 예외가 필터에서 잡히지 않고 있었습니다. 문제를 해결하기 위해 catchError 연산자에서 throwError를 사용하여 예외를 다시 던졌지만, 여전히 Promise 컨텍스트에서 예외가 제대로 전달되지 않는 문제가 있었습니다. 이로 인해 CustomWsException이 WebSocket 필터에서 처리되지 않아, Unhandled Rejection 상태로 서버가 종료되고 있었습니다.

- 그래서 어쩔수 없이 main.ts에서 process.on('uncaughtException')와 process.on('unhandledRejection') 이벤트 핸들러를 추가하여, 처리되지 않은 예외를 잡게 만들었습니다. 이를 통해 예상치 못한 예외로 인해 서버가 종료되는 문제를 해결했습니다.

## 😭 어려웠던 점
사실 왜 아직도 필터에서 예외를 못잡는지 이해하지 못했습니다. 아래 코드처럼 catchError와 throwError를 사용해 Observable에서 발생한 예외를 명시적으로 처리하고, 이를 firstValueFrom을 통해 Promise로 전달하려고 했지만, CustomWsException이 WebSocket 필터에서 여전히 예외를 잡지 못했습니다.

``` ts
  async delete<T>(path: string, data?: any): Promise<T> {
    try {
      const response = await firstValueFrom(
        this.httpService.delete<T>(`${this.baseUrl}${path}`, data).pipe(
          catchError(error => {
            return throwError(() => error);
          }),
        ),
      );
      return response.data;
    } catch (error) {
      this.handleError(error);
    }
  }
```