### PR TITLE
[Fix] chat 서버 createRoom 방식 변경 및 로거 추가

### DIFF
--- a/apps/chat/src/chat/chat.gateway.ts
+++ b/apps/chat/src/chat/chat.gateway.ts
@@ -17,7 +17,7 @@ export class ChatGateway {
 
   //룸생성
   @SubscribeMessage('createRoom')
-  async handleCreateRoom(params: createRoomDto, @ConnectedSocket() client: Socket) {
+  async handleCreateRoom(@MessageBody() params: createRoomDto, @ConnectedSocket() client: Socket) {
     const roomId = this.chatService.createRoom(params, client);
 
     return {
@@ -26,7 +26,7 @@ export class ChatGateway {
   }
   //룸입장
   @SubscribeMessage('joinRoom')
-  async handleJoinRoom(params: joinRoomDto, @ConnectedSocket() client: Socket) {
+  async handleJoinRoom(@MessageBody() params: joinRoomDto, @ConnectedSocket() client: Socket) {
     this.chatService.joinRoom(params, client);
   }
   //룸나가기
@@ -41,7 +41,7 @@ export class ChatGateway {
   }
   //채팅
   @SubscribeMessage('chat')
-  async handleChat(params: chatDto) {
+  async handleChat(@MessageBody() params: chatDto) {
     this.chatService.broadcast(params);
   }
 }

--- a/apps/chat/src/chat/chat.service.ts
+++ b/apps/chat/src/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Socket } from 'socket.io';
 import { CustomWsException } from 'src/common/responses/exceptions/custom-ws.exception';
 import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
@@ -14,31 +14,32 @@ interface IRoom {
 
 @Injectable()
 export class ChatService {
-  rooms = new Map<string, IRoom>();
+  private rooms = new Map<string, IRoom>();
+  private readonly logger = new Logger(ChatService.name);
 
   createRoom(params: createRoomDto, client: Socket) {
     const { name, camperId, roomId } = params;
-
     const newClient = new Client(name, camperId, client);
 
     const room = {
       ownerId: client.id,
       clients: [newClient],
     };
-    this.rooms.set(roomId, room);
 
+    this.rooms.set(roomId, room);
+    this.logger.log(`Chat Room created: ${roomId}`);
     return roomId;
   }
 
   joinRoom(params: joinRoomDto, client: Socket) {
     const { name, camperId, roomId } = params;
     const room = this.rooms.get(roomId);
-
     if (!room) new CustomWsException(ErrorStatus.ROOM_NOT_FOUND);
 
     const newClient = new Client(name, camperId, client);
 
     room.clients.push(newClient);
+    this.logger.log(`Client Join Room: ${room}`);
   }
 
   leaveRoom(roomId: string, client: Socket) {
@@ -54,6 +55,7 @@ export class ChatService {
     };
 
     this.rooms.set(roomId, updatedRoom);
+    this.logger.log(`Client Leave Room: ${room}`);
   }
 
   deleteRoom(roomId: string, client: Socket) {
@@ -63,6 +65,7 @@ export class ChatService {
     if (room.ownerId !== client.id) new CustomWsException(ErrorStatus.NO_HAVE_AUTHORITY_IN_ROOM);
 
     this.rooms.delete(roomId);
+    this.logger.log(`Delete Chat Room: ${roomId}`);
   }
 
   broadcast(params: chatDto) {
@@ -74,5 +77,6 @@ export class ChatService {
     room.clients.forEach(client => {
       client.sendMessage(message);
     });
+    this.logger.log(`BroadCast to Clients: room#${roomId} message#${message}}`);
   }
 }

--- a/apps/chat/src/chat/chat.service.ts
+++ b/apps/chat/src/chat/chat.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { randomUUID } from 'crypto';
 import { Socket } from 'socket.io';
 import { CustomWsException } from 'src/common/responses/exceptions/custom-ws.exception';
 import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
@@ -18,9 +17,8 @@ export class ChatService {
   rooms = new Map<string, IRoom>();
 
   createRoom(params: createRoomDto, client: Socket) {
-    const { name, camperId } = params;
+    const { name, camperId, roomId } = params;
 
-    const roomId = randomUUID();
     const newClient = new Client(name, camperId, client);
 
     const room = {

--- a/apps/chat/src/chat/dto/creat-room.dto.ts
+++ b/apps/chat/src/chat/dto/creat-room.dto.ts
@@ -1,4 +1,5 @@
 export class createRoomDto {
   name: string;
   camperId: string;
+  roomId: string;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #222 

## ✨ 구현 기능 명세
- createRoom 함수에서 기존 방송 roomId를 받아 방 생성하도록 로직 수정
- MessageBody 데코레이터 추가
- 로거 추가

## 🎁 PR Point
- 클라이언트 입장에서 chat의 아이디가 방송과 다르면 알 수 있는 방법이 없어서 로직을 변경하였습니다.
- 서버에서 확인이 가능하도록 로거를 추가했습니다.
