### PR TITLE
:sparkles: [Feat]: 방송 종료 시 record 서버 리소스 정리 구현

### DIFF
--- a/apps/media/src/sfu/services/record.service.ts
+++ b/apps/media/src/sfu/services/record.service.ts
@@ -8,7 +8,7 @@ export class RecordService {
 
   async sendStream(room: mediasoup.types.Router, producer: mediasoup.types.Producer) {
     if (producer.kind === 'audio') return;
-    const transport = await this.createPlainTransport(room);
+    const recordTransport = await this.createPlainTransport(room);
     const codecs = [];
     const routerCodec = room.rtpCapabilities.codecs.find(codec => codec.kind === producer.kind);
     codecs.push(routerCodec);
@@ -16,20 +16,15 @@ export class RecordService {
       codecs,
       rtcpFeedback: [],
     };
-    const rtpConsumer = await transport.consume({
+    const recordConsumer = await recordTransport.consume({
       producerId: producer.id,
       rtpCapabilities,
       paused: true,
     });
 
-    await rtpConsumer.setPreferredLayers({
-      spatialLayer: 2,
-      temporalLayer: 2,
-    });
-
     setTimeout(async () => {
-      await rtpConsumer.resume();
-      await rtpConsumer.requestKeyFrame();
+      await recordConsumer.resume();
+      await recordConsumer.requestKeyFrame();
     }, 1000);
 
     const { port } = await this.httpservice
@@ -37,10 +32,13 @@ export class RecordService {
       .toPromise()
       .then(({ data }) => data);
 
-    await transport.connect({
+    await recordTransport.connect({
       ip: '127.0.0.1',
       port,
     });
+
+    this.setUpRecordTransportListeners(recordTransport, port);
+    this.setUpRecordConsumerListeners(recordConsumer);
 
     await this.httpservice
       .post('http://localhost:3003/send', {
@@ -59,6 +57,23 @@ export class RecordService {
         portRange: { min: 30000, max: 31000 },
       },
       rtcpMux: true,
+    });
+  }
+
+  private setUpRecordTransportListeners(recordTransport: mediasoup.types.Transport, port: number) {
+    recordTransport.on('routerclose', async () => {
+      await this.httpservice
+        .post(`${this.configService.get('RECORD_SERVER_URL')}/close`, {
+          port,
+        })
+        .toPromise();
+      recordTransport.close();
+    });
+  }
+
+  private setUpRecordConsumerListeners(recordConsumer: mediasoup.types.Consumer) {
+    recordConsumer.on('transportclose', () => {
+      recordConsumer.close();
     });
   }
 }

--- a/apps/record/src/index.ts
+++ b/apps/record/src/index.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import dotenv from 'dotenv';
 import { createFfmpegProcess } from './ffmpeg';
 import express from 'express';
-import { getPort } from './port';
+import { getPort, releasePort } from './port';
 
 dotenv.config();
 const app = express();
@@ -35,6 +35,12 @@ app.get('/images/:roomId', (req, res) => {
     }
     res.sendFile(thumbnailPath);
   });
+});
+
+app.post('/close', (req, res) => {
+  const { port } = req.body;
+  releasePort(port);
+  res.send({ success: true });
 });
 
 app.listen(3003);

--- a/apps/record/src/port.ts
+++ b/apps/record/src/port.ts
@@ -8,13 +8,12 @@ export const getPort = () => {
   while (takenPort.has(port)) {
     port = getRandomPort();
   }
-  takenPort.add(port).add(port + 1);
+  takenPort.add(port);
   return port;
 };
 
 export const releasePort = (port: number) => {
   takenPort.delete(port);
-  takenPort.delete(port + 1);
 };
 
 const getRandomPort = () => {

--- a/apps/record/src/port.ts
+++ b/apps/record/src/port.ts
@@ -8,12 +8,13 @@ export const getPort = () => {
   while (takenPort.has(port)) {
     port = getRandomPort();
   }
-  takenPort.add(port);
+  takenPort.add(port).add(port + 1);
   return port;
 };
 
 export const releasePort = (port: number) => {
   takenPort.delete(port);
+  takenPort.delete(port + 1);
 };
 
 const getRandomPort = () => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #220 

## ✨ 구현 기능 명세
- 사용중인 포트 한 방송당 2개 등록
- router close시 transport close 및 record 서버 port 정리 되도록 이벤트 등록
- transport close시 consumer close되도록 이벤트 등록

## 🎁 PR Point
- ffmpeg은 방송 하나 당 연속 2개의 포트를 사용하고 있는데 기존 코드는 한개만 사용중으로 등록되어 연속 두개의 포트가 등록되도록 수정하였습니다.
- 방송이 종료되면 ffmpeg에서 사용하는 두개의 포트가 반납되는것 확인했습니다.
![스크린샷 2024-11-20 오후 11 22 42](https://github.com/user-attachments/assets/761d3b3e-f1fd-43d0-9b67-ec212b874b9e)
- 방송 종료 후에 다시 방송을 켜도 ffmpeg이 잘 동작하고 썸네일이 생성되는것을 확인했습니다.
- 방송을 여러명이 킨 상태에서 한명만 종료했을때 그 한명의 port만 반납되고 나머지 방송 스트림은 잘 전송되어 썸네일이 생성되는것을 확인했습니다.
## 😭 어려웠던 점
