### PR TITLE
[Feat] chat 이름 오류 수정 및 소켓 종료 로직 구현

### DIFF
--- a/apps/chat/src/chat/chat.gateway.ts
+++ b/apps/chat/src/chat/chat.gateway.ts
@@ -41,7 +41,7 @@ export class ChatGateway {
   }
   //채팅
   @SubscribeMessage('chat')
-  async handleChat(@MessageBody() params: chatDto) {
-    this.chatService.broadcast(params);
+  async handleChat(@MessageBody() params: chatDto, @ConnectedSocket() client: Socket) {
+    this.chatService.broadcast(params, client);
   }
 }

--- a/apps/chat/src/chat/chat.gateway.ts
+++ b/apps/chat/src/chat/chat.gateway.ts
@@ -1,4 +1,11 @@
-import { ConnectedSocket, MessageBody, SubscribeMessage, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { UseFilters } from '@nestjs/common';
 import { WebSocketExceptionFilter } from 'src/common/filter/webSocketExceptionFilter';
@@ -9,7 +16,7 @@ import { chatDto } from './dto/chat.dto';
 
 @WebSocketGateway({ cors: { origin: '*', methods: ['GET', 'POST'] } })
 @UseFilters(WebSocketExceptionFilter)
-export class ChatGateway {
+export class ChatGateway implements OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
 
@@ -43,5 +50,9 @@ export class ChatGateway {
   @SubscribeMessage('chat')
   async handleChat(@MessageBody() params: chatDto, @ConnectedSocket() client: Socket) {
     this.chatService.broadcast(params, client);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.chatService.disconnect(client);
   }
 }

--- a/apps/chat/src/chat/chat.service.ts
+++ b/apps/chat/src/chat/chat.service.ts
@@ -68,15 +68,18 @@ export class ChatService {
     this.logger.log(`Delete Chat Room: ${roomId}`);
   }
 
-  broadcast(params: chatDto) {
+  broadcast(params: chatDto, client: Socket) {
     const { roomId, message } = params;
     const room = this.rooms.get(roomId);
 
     if (!room) new CustomWsException(ErrorStatus.ROOM_NOT_FOUND);
 
-    room.clients.forEach(client => {
-      client.sendMessage(message);
+    const sendClient = room.clients.find(anyClient => anyClient.getSocket() === client);
+
+    room.clients.forEach(anyClient => {
+      anyClient.sendMessage(sendClient.getName(), sendClient.getName(), message);
     });
+
     this.logger.log(`BroadCast to Clients: room#${roomId} message#${message}}`);
   }
 }

--- a/apps/chat/src/chat/chat.service.ts
+++ b/apps/chat/src/chat/chat.service.ts
@@ -9,24 +9,29 @@ import { chatDto } from './dto/chat.dto';
 
 interface IRoom {
   ownerId: string;
-  clients: Client[];
+  clients: Map<string, Client>;
 }
 
 @Injectable()
 export class ChatService {
   private rooms = new Map<string, IRoom>();
+  private ownerToRoom = new Map<string, string>();
+  private clientToRoom = new Map<string, string>();
   private readonly logger = new Logger(ChatService.name);
 
   createRoom(params: createRoomDto, client: Socket) {
     const { name, camperId, roomId } = params;
-    const newClient = new Client(name, camperId, client);
+    const newClient = new Client(camperId, name, client);
 
     const room = {
       ownerId: client.id,
-      clients: [newClient],
+      clients: new Map(),
     };
 
+    room.clients.set(client.id, newClient);
+    this.ownerToRoom.set(client.id, roomId);
     this.rooms.set(roomId, room);
+
     this.logger.log(`Chat Room created: ${roomId}`);
     return roomId;
   }
@@ -36,10 +41,11 @@ export class ChatService {
     const room = this.rooms.get(roomId);
     if (!room) new CustomWsException(ErrorStatus.ROOM_NOT_FOUND);
 
-    const newClient = new Client(name, camperId, client);
+    const newClient = new Client(camperId, name, client);
 
-    room.clients.push(newClient);
-    this.logger.log(`Client Join Room: ${room}`);
+    room.clients.set(client.id, newClient);
+    this.clientToRoom.set(client.id, roomId);
+    this.logger.log(`Client Join Room: ${roomId}`);
   }
 
   leaveRoom(roomId: string, client: Socket) {
@@ -47,15 +53,9 @@ export class ChatService {
 
     if (!room) new CustomWsException(ErrorStatus.ROOM_NOT_FOUND);
 
-    const updatedClients = room.clients.filter(anyClient => anyClient.getSocket() !== client);
+    room.clients.delete(client.id);
 
-    const updatedRoom = {
-      ...room,
-      clients: updatedClients,
-    };
-
-    this.rooms.set(roomId, updatedRoom);
-    this.logger.log(`Client Leave Room: ${room}`);
+    this.logger.log(`Client Leave Room: ${roomId}`);
   }
 
   deleteRoom(roomId: string, client: Socket) {
@@ -74,12 +74,25 @@ export class ChatService {
 
     if (!room) new CustomWsException(ErrorStatus.ROOM_NOT_FOUND);
 
-    const sendClient = room.clients.find(anyClient => anyClient.getSocket() === client);
+    const sendClient = room.clients.get(client.id);
 
     room.clients.forEach(anyClient => {
       anyClient.sendMessage(sendClient.getName(), sendClient.getName(), message);
     });
 
     this.logger.log(`BroadCast to Clients: room#${roomId} message#${message}}`);
+  }
+
+  disconnect(client: Socket) {
+    if (this.ownerToRoom.has(client.id)) {
+      //방삭제
+      const roomId = this.ownerToRoom.get(client.id);
+      this.deleteRoom(roomId, client);
+    }
+    if (this.clientToRoom.has(client.id)) {
+      //방 떠나기
+      const roomId = this.clientToRoom.get(client.id);
+      this.leaveRoom(roomId, client);
+    }
   }
 }

--- a/apps/chat/src/chat/client.ts
+++ b/apps/chat/src/chat/client.ts
@@ -23,10 +23,10 @@ export class Client {
     return this.socket;
   }
 
-  sendMessage(message: string) {
+  sendMessage(camperId: string, name: string, message: string) {
     this.socket.emit('chat', {
-      camperId: this.camperId,
-      name: this.name,
+      camperId,
+      name,
       message,
     });
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #225 

## ✨ 구현 기능 명세
- chat 이름 오류 수정
- 소켓 종료 로직 구현

## 🎁 PR Point
- room에 clients 저장 방식을 변경하였습니다. 기존에는 단순 배열이었는데 그러면 클라이언트를 찾을때 반복문을 돌아야 해서 map 형태로 `clientId : socket`으로 저장되게 구현하였습니다.
- 소켓 종료 시 송출자인지 시청자인지를 구분하기 위해 ownerToRoom, clientToRoom 객체를 추가하였습니다.

## 😭 어려웠던 점
- 없습니다