### PR TITLE
[Fix] 실시간 방송 썸네일 시간 간격 조정

### DIFF
--- a/apps/record/src/ffmpeg.ts
+++ b/apps/record/src/ffmpeg.ts
@@ -49,7 +49,7 @@ const commandArgs = (dirPath: string, roomId: string) => {
     '-i',
     'pipe:0', // SDP를 파이프로 전달
     '-vf',
-    'fps=1/30,scale=1280:720', // 10초마다 한 프레임을 캡처하고 해상도 조정
+    'fps=1/10,scale=1280:720', // 10초마다 한 프레임을 캡처하고 해상도 조정
     '-update',
     '1', // 같은 파일에 덮어쓰기 활성화
     `${dirPath}/${roomId}.jpg`, // 덮어쓸 출력 파일 이름


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #235 

## ✨ 구현 기능 명세
- 썸네일 시간 간격 10초로 변경

## 🎁 PR Point
- 원활한 데모 발표를 위해 변경하였습니다.

## 😭 어려웠던 점
- 없습니다.