### PR TITLE
[Feat] 채팅창 자동 스크롤 구현 및 아래서 부터 올라오도록 수정

### DIFF
--- a/apps/client/src/components/ChatContainer.tsx
+++ b/apps/client/src/components/ChatContainer.tsx
@@ -112,8 +112,8 @@ const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boo
         </div>
       ) : (
         <>
-          <CardContent ref={scrollAreaRef} className="flex flex-1 px-6 pb-2 justify-end overflow-y-auto">
-            <div className="w-full pr-4 flex flex-col space-y-3 ">
+          <CardContent ref={scrollAreaRef} className="flex flex-1 px-6 pb-2 overflow-y-auto flex-col-reverse">
+            <div className="w-full flex flex-col space-y-1">
               {chattings.map((chat, index) => (
                 <div key={index}>
                   <span className="font-medium text-display-medium16 text-text-weak">{chat.camperId} </span>

--- a/apps/client/src/components/ChatContainer.tsx
+++ b/apps/client/src/components/ChatContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import SmileIcon from './icons/SmileIcon';
@@ -21,17 +21,13 @@ const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boo
   const [chattings, setChattings] = useState<Chat[]>([]);
   const [inputValue, setInputValue] = useState<string>('');
   const [isComposing, setIsComposing] = useState(false);
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
   // 스크롤
-  // const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
-  // const scrollAreaRef = useRef<HTMLDivElement>(null);
-
-  // const handleScroll = () => {
-  //   if (scrollAreaRef.current) {
-  //     const { scrollTop, scrollHeight, clientHeight } = scrollAreaRef.current;
-  //     const isAtBottom = scrollHeight - scrollTop - clientHeight < 20;
-  //     setShouldAutoScroll(isAtBottom);
-  //   }
-  // };
+  const scrollToBottom = () => {
+    if (scrollAreaRef.current) {
+      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
+    }
+  };
 
   const setUpRoom = async (isProducer: boolean) => {
     try {
@@ -101,14 +97,9 @@ const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boo
   }, [isConnected, roomId, socket]);
 
   // 자동 스크롤
-  // useEffect(() => {
-  //   if (scrollAreaRef.current && shouldAutoScroll) {
-  //     scrollAreaRef.current.scrollTo({
-  //       top: scrollAreaRef.current.scrollHeight,
-  //       behavior: 'smooth',
-  //     });
-  //   }
-  // }, [chattings]);
+  useEffect(() => {
+    scrollToBottom();
+  }, [chattings]);
 
   return (
     <Card className="flex flex-col flex-1 border-border-default bg-transparent shadow-none overflow-hidden">
@@ -121,7 +112,7 @@ const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boo
         </div>
       ) : (
         <>
-          <CardContent className="flex flex-1 px-6 pb-2 justify-end overflow-y-auto">
+          <CardContent ref={scrollAreaRef} className="flex flex-1 px-6 pb-2 justify-end overflow-y-auto">
             <div className="w-full pr-4 flex flex-col space-y-3 ">
               {chattings.map((chat, index) => (
                 <div key={index}>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #237 

## ✨ 구현 기능 명세
- 채팅창이 자동으로 bottom으로 포커싱 되도록 구현
- 채팅창이 아래에서 부터 올라오도록 css 수정

## 🎁 PR Point
### 채팅창 자동 스크롤
```javascript
const scrollToBottom = () => {
    if (scrollAreaRef.current) {
      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
    }
  };
```
- useEffect 의존성 배열에 chattings를 넣어줬고, 채팅이 새로 생길때마다 위의 함수가 실행되도록 구현했습니다.
- scrollHeight는 스크롤 요소의 height를 의미합니다. 채팅이 100개면 100개 합친 높이가 되는거에요.
- scrollTop은 스크롤 요소의 상단부터 지금 보이는 부분까지의 거리를 의미합니다. 지금 20번째 채팅을 보고있으면 20번째 채팅까지의 height이 scrollTop이 됩니다.
- scrollTop을 scrollHeight으로 지정해주면 지금 보고있는 부분이 가장 마지막 부분이 됩니다. (지금 보고있는 부분이 100번째 채팅이라고 해주는것과 같으니까요)
- scrollRef는 overflow-y-auto 태그가 달린 부분에 추가했습니다.
- 참고자료 : https://ko.javascript.info/size-and-scroll

### 채팅창 아래에서 부터 올라오도록 수정
```
<CardContent ref={scrollAreaRef} className="flex flex-1 px-6 pb-2 overflow-y-auto flex-col-reverse">
  <div className="w-full flex flex-col space-y-1">
    {chattings.map((chat, index) => (
      <div key={index}>
        <span className="font-medium text-display-medium16 text-text-weak">{chat.camperId} </span>
        <span className="font-medium text-display-medium14 text-text-strong">{chat.message}</span>
      </div>
    ))}
  </div>
</CardContent>
```
- 일단 chatting 컴포넌트들 을 하나의 div로 더 감쌌습니다.
- 기존 CardContent 태그에 flex-col-reverse (justify-content: col-reverse)를 적용시켰습니다. 그러면 내부의 자식요소들이 아래에서 부터 보이도록 배치되게 됩니다. (현재 자식 요소가 추가한 div 하나밖에 없기 때문에 그냥 맨 아래에 배치되게 됩니다)
- 추가한 div는 justify-content: column만 설정하여 수직정렬 되도록 했습니다. 거꾸로 뒤집히면 안되니까요. (채팅이 너무 다닥다닥 붙어있어서 gap도 줬습니다.)
- div를 추가한 이유는 추가하지 않으면 flex-col-reverse가 채팅 컴포넌트 하나하나에 적용되게 되어 거꾸로 쌓이기 때문입니다!

### 결과
https://github.com/user-attachments/assets/a6547a48-4583-463e-b0dc-4a3b7a1555dd


## 😭 어려웠던 점
- 집 와서 좀 쉬고 밥도 먹고 보니 바로 해결됩니다. 역시 코딩은 쉬면서 해야합니다.
