### PR TITLE
⚡️ [Feat] 검색 api 구현 및 방송 리스트 api에 필터링 기능 추가

### DIFF
--- a/apps/api/src/broadcast/broadcast.controller.ts
+++ b/apps/api/src/broadcast/broadcast.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
 import { BroadcastService } from './broadcast.service';
 import { SuccessStatus } from '../common/responses/bases/successStatus';
 import { BroadcastListResponseDto } from './dto/broadcast-list-response.dto';
@@ -11,6 +11,7 @@ import { SwaggerTag } from 'src/common/constants/swagger-tag.enum';
 import { ApiSuccessResponse } from 'src/common/decorators/success-res.decorator';
 import { ApiErrorResponse } from 'src/common/decorators/error-res.decorator';
 import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
+import { BroadcastSearchResponseDto } from './dto/broadcast-search-response.dto';
 
 @Controller('v1/broadcasts')
 export class BroadcastController {
@@ -54,6 +55,16 @@ export class BroadcastController {
     await this.broadcastService.updateTitle(null, updateBroadcastTitleDto);
 
     return SuccessStatus.OK(null, '제목 수정이 완료 되었습니다.');
+  }
+
+  @Get('/search')
+  @ApiTags(SwaggerTag.MAIN)
+  @ApiOperation({ summary: '방송 검색' })
+  @ApiSuccessResponse(SuccessStatus.OK(BroadcastSearchResponseDto), BroadcastSearchResponseDto)
+  @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
+  async searchBroadcasts(@Query('keyword') keyword: string) {
+    const broadcasts = await this.broadcastService.searchBroadcasts(keyword);
+    return SuccessStatus.OK(BroadcastSearchResponseDto.fromList(broadcasts));
   }
 
   @Post()

--- a/apps/api/src/broadcast/broadcast.controller.ts
+++ b/apps/api/src/broadcast/broadcast.controller.ts
@@ -12,6 +12,8 @@ import { ApiSuccessResponse } from 'src/common/decorators/success-res.decorator'
 import { ApiErrorResponse } from 'src/common/decorators/error-res.decorator';
 import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
 import { BroadcastSearchResponseDto } from './dto/broadcast-search-response.dto';
+import { FieldEnum } from 'src/member/enum/field.enum';
+import { CustomException } from 'src/common/responses/exceptions/custom.exception';
 
 @Controller('v1/broadcasts')
 export class BroadcastController {
@@ -22,9 +24,13 @@ export class BroadcastController {
   @ApiOperation({ summary: '방송 리스트 조회' })
   @ApiSuccessResponse(SuccessStatus.OK(BroadcastListResponseDto), BroadcastListResponseDto)
   @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
-  async getAll() {
-    const broadcasts = await this.broadcastService.getAll();
-    return SuccessStatus.OK(BroadcastListResponseDto.from(broadcasts));
+  async getAllWithFilter(@Query('field') field: FieldEnum) {
+    if (field && !Object.values(FieldEnum).includes(field as FieldEnum)) {
+      throw new CustomException(ErrorStatus.INVALID_FIELD);
+    }
+
+    const broadcasts = await this.broadcastService.getAllWithFilter(field);
+    return SuccessStatus.OK(BroadcastListResponseDto.fromList(broadcasts));
   }
 
   @Get('/:broadcastId/info')

--- a/apps/api/src/broadcast/broadcast.service.ts
+++ b/apps/api/src/broadcast/broadcast.service.ts
@@ -7,6 +7,7 @@ import { UpdateBroadcastTitleDto } from './dto/update-broadcast-title.request.dt
 import { CustomException } from 'src/common/responses/exceptions/custom.exception';
 import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
 import { Attendance } from 'src/attendance/attendance.entity';
+import { FieldEnum } from 'src/member/enum/field.enum';
 
 @Injectable()
 export class BroadcastService {
@@ -15,11 +16,16 @@ export class BroadcastService {
     @InjectRepository(Attendance) private readonly attendanceRepository: Repository<Attendance>,
   ) {}
 
-  async getAll() {
-    return this.broadcastRepository
+  async getAllWithFilter(field?: FieldEnum): Promise<Broadcast[]> {
+    const query = this.broadcastRepository
       .createQueryBuilder('broadcast')
-      .leftJoinAndSelect('broadcast.member', 'member')
-      .getMany();
+      .leftJoinAndSelect('broadcast.member', 'member');
+
+    if (field) {
+      query.where('member.filed = :field', { field });
+    }
+
+    return query.getMany();
   }
 
   async getBroadcastInfo(broadcastId: string) {

--- a/apps/api/src/broadcast/broadcast.service.ts
+++ b/apps/api/src/broadcast/broadcast.service.ts
@@ -55,6 +55,18 @@ export class BroadcastService {
     await this.broadcastRepository.update(broadcast.id, broadcast);
   }
 
+  async searchBroadcasts(keyword: string): Promise<Broadcast[]> {
+    if (!keyword) {
+      return [];
+    }
+
+    return this.broadcastRepository
+      .createQueryBuilder('broadcast')
+      .leftJoinAndSelect('broadcast.member', 'member')
+      .where('broadcast.title LIKE :keyword', { keyword: `%${keyword}%` })
+      .getMany();
+  }
+
   async createBroadcast({ id, title, thumbnail }: CreateBroadcastDto): Promise<Broadcast> {
     const broadcast = this.broadcastRepository.create({
       id,

--- a/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
@@ -21,16 +21,18 @@ export class BroadcastListResponseDto {
   @ApiProperty({ example: 'WEB' })
   field: FieldEnum;
 
-  static from(broadcasts: Broadcast[]) {
-    return broadcasts.map(broadcast => {
-      const dto = new BroadcastListResponseDto();
-      dto.broadcastId = broadcast.id;
-      dto.broadcastTitle = broadcast.title;
-      dto.thumbnail = broadcast.thumbnail;
-      dto.camperId = broadcast.member ? broadcast.member.camperId : '';
-      dto.profileImage = broadcast.member ? broadcast.member.profileImage : '';
-      dto.field = broadcast.member ? broadcast.member.filed : FieldEnum.WEB;
-      return dto;
-    });
+  static from(broadcast: Broadcast): BroadcastListResponseDto {
+    const dto = new BroadcastListResponseDto();
+    dto.broadcastId = broadcast.id;
+    dto.broadcastTitle = broadcast.title;
+    dto.thumbnail = broadcast.thumbnail;
+    dto.camperId = broadcast.member ? broadcast.member.camperId : '';
+    dto.profileImage = broadcast.member ? broadcast.member.profileImage : '';
+    dto.field = broadcast.member ? broadcast.member.filed : FieldEnum.WEB;
+    return dto;
+  }
+
+  static fromList(broadcasts: Broadcast[]): BroadcastListResponseDto[] {
+    return broadcasts.map(broadcast => this.from(broadcast));
   }
 }

--- a/apps/api/src/broadcast/dto/broadcast-search-response.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-search-response.dto.ts
@@ -1,0 +1,26 @@
+import { Broadcast } from '../broadcast.entity';
+import { FieldEnum } from '../../member/enum/field.enum';
+
+export class BroadcastSearchResponseDto {
+  broadcastId: string;
+  broadcastTitle: string;
+  thumbnail: string;
+  camperId: string;
+  profileImage: string;
+  field: FieldEnum;
+
+  static from(broadcast: Broadcast): BroadcastSearchResponseDto {
+    const dto = new BroadcastSearchResponseDto();
+    dto.broadcastId = broadcast.id;
+    dto.broadcastTitle = broadcast.title;
+    dto.thumbnail = broadcast.thumbnail;
+    dto.camperId = broadcast.member?.camperId;
+    dto.profileImage = broadcast.member?.profileImage;
+    dto.field = broadcast.member?.filed;
+    return dto;
+  }
+
+  static fromList(broadcasts: Broadcast[]): BroadcastSearchResponseDto[] {
+    return broadcasts.map(broadcast => this.from(broadcast));
+  }
+}

--- a/apps/api/src/common/responses/exceptions/errorStatus.ts
+++ b/apps/api/src/common/responses/exceptions/errorStatus.ts
@@ -15,6 +15,12 @@ export class ErrorStatus {
 
   static readonly INVALID_TOKEN = new ErrorStatus(400, 'MEMBER_4002', '유효하지 않은 토큰입니다.');
 
+  static readonly INVALID_FIELD = new ErrorStatus(
+    400,
+    'MEMBER_4003',
+    '유효하지 않은 분야입니다. (WEB, AND, IOS 중 하나여야 합니다)',
+  );
+
   // Broadcast Errors
   static readonly BROADCAST_NOT_FOUND = new ErrorStatus(404, 'BROADCAST_4000', '방송 정보가 존재하지 않습니다.');
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
- #252 

## ✨ 구현 기능 명세
- 검색 api 구현
  - ![image](https://github.com/user-attachments/assets/ce76bd25-d3dd-4b77-b1b5-264073f092d2)
- 방송 리스트 api 에 필터링 기능 추가
  - ![image](https://github.com/user-attachments/assets/e3432800-1c6e-45d1-b672-7f90ec166613)

## 🎁 PR Point
### 검색 api
- 검색 기준 : only 방송 제목
- 키워드가 없는 경우 : 빈 배열 반환

### 방송 리스트 api에 필터링 기능 추가
- 필터링 태그에 속하지 않는다면 에러 발생(WEB, AND, IOS 이외의 키워드 요청 시 에러)

### dto의 from 메서드 책임 분리
- from 함수 : 다른 객체를 기반으로 dto를 반환해주는 메서드
- 기존 방식:  from으로 **dto의 리스트**를 반환하고 있었음
- 수정 방식 : from 함수는 **단일 객체**만 반환, **dto의 배열을 반환하는 메서드**를 별도로 만들어서 사용

## 😭 어려웠던 점
