### PR TITLE
[Feat] 개인 정보 수정 API 구현

### DIFF
--- a/apps/api/src/common/pipe/custom-validation.pipe.ts
+++ b/apps/api/src/common/pipe/custom-validation.pipe.ts
@@ -5,6 +5,7 @@ import { CustomException } from '../responses/exceptions/custom.exception';
 export class CustomValidationPipe extends ValidationPipe {
   constructor() {
     super({
+      transform: true,
       exceptionFactory: (errors: ValidationError[]) => {
         const messages = this.flattenValidationErrors(errors);
 

--- a/apps/api/src/config/swagger.config.ts
+++ b/apps/api/src/config/swagger.config.ts
@@ -8,6 +8,7 @@ export class ConfigSwagger {
       .setTitle("Cam'ON API 문서")
       .setDescription("Cam'ON 서비스의 api 문서입니다.")
       .setVersion('1.0')
+      .addBearerAuth()
       .addTag(SwaggerTag.HEADER)
       .addTag(SwaggerTag.MAIN)
       .addTag(SwaggerTag.WATCH)

--- a/apps/api/src/member/dto/update-member-info.dto.ts
+++ b/apps/api/src/member/dto/update-member-info.dto.ts
@@ -1,0 +1,37 @@
+import { FieldEnum } from '../enum/field.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { Member } from '../member.entity';
+
+class Contacts {
+  @ApiProperty({ example: 'test@naver.com' })
+  email: string;
+  @ApiProperty()
+  github: string;
+  @ApiProperty()
+  blog: string;
+  @ApiProperty()
+  linkedin: string;
+}
+
+export class UpdateMemberInfoDto {
+  @ApiProperty({ example: '홍길동' })
+  name: string;
+  @ApiProperty({ example: 'J000' })
+  camperId: string;
+  @ApiProperty({ example: 'WEB' })
+  type: FieldEnum;
+  @ApiProperty({ type: Contacts })
+  contacts: Contacts;
+
+  toMember() {
+    const member = new Member();
+    member.name = this.name;
+    member.camperId = this.camperId;
+    member.filed = this.type;
+    member.email = this.contacts.email;
+    member.github = this.contacts.github;
+    member.blog = this.contacts.blog;
+    member.linkedin = this.contacts.linkedin;
+    return member;
+  }
+}

--- a/apps/api/src/member/member.controller.ts
+++ b/apps/api/src/member/member.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Patch, UseGuards } from '@nestjs/common';
+import { JWTAuthGuard } from '../auth/guard/jwt-auth.guard';
+import { UpdateMemberInfoDto } from './dto/update-member-info.dto';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { SwaggerTag } from '../common/constants/swagger-tag.enum';
+import { MemberService } from './member.service';
+import { UserReq } from '../common/decorators/user-req.decorator';
+import { Member } from './member.entity';
+import { ApiSuccessResponse } from '../common/decorators/success-res.decorator';
+import { SuccessStatus } from '../common/responses/bases/successStatus';
+import { ApiErrorResponse } from '../common/decorators/error-res.decorator';
+import { ErrorStatus } from '../common/responses/exceptions/errorStatus';
+
+@Controller('v1/members')
+@UseGuards(JWTAuthGuard)
+@ApiBearerAuth()
+export class MemberController {
+  constructor(private readonly memberService: MemberService) {}
+
+  @Patch('info')
+  @ApiTags(SwaggerTag.MYPAGE)
+  @ApiOperation({ summary: '내 정보 수정' })
+  @ApiBody({ type: UpdateMemberInfoDto })
+  @ApiSuccessResponse(SuccessStatus.OK(null))
+  @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
+  @ApiErrorResponse(400, ErrorStatus.INVALID_TOKEN)
+  async updateMemberInfo(@UserReq() member: Member, @Body() updateMemberInfoDto: UpdateMemberInfoDto) {
+    await this.memberService.updateMemberInfo(member.id, updateMemberInfoDto.toMember());
+  }
+}

--- a/apps/api/src/member/member.module.ts
+++ b/apps/api/src/member/member.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { MemberService } from './member.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Member } from './member.entity';
+import { MemberController } from './member.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Member])],
+  controllers: [MemberController],
   providers: [MemberService],
   exports: [MemberService],
 })

--- a/apps/api/src/member/member.service.ts
+++ b/apps/api/src/member/member.service.ts
@@ -25,4 +25,8 @@ export class MemberService {
   async createMember(member: Member) {
     return await this.memberRepository.save(member);
   }
+
+  async updateMemberInfo(id: number, member: Member) {
+    await this.memberRepository.update(id, member);
+  }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #13

## ✨ 구현 기능 명세
- 회원 정보 수정 API 구현
## 🎁 PR Point
- Swagger에서도 테스트 할 수 있게 스웨거에서 토큰을 추가할 수 있게 수정

## 😭 어려웠던 점
- DTO에서 `toMember()` 메서드가 호출이 안되는 문제가 있었습니다. 이는 요청 데이터가 DTO 인스턴스가 아니라 평번한 객체로 전달되면서 발생했던 문제였습니다. 이를 해결하기 위해 validationPipe에 transform:true를 추가해줬습니다.