### PR TITLE
[Feat] 미디어서버 화질 조정 이벤트 구현

### DIFF
--- a/apps/media/src/sfu/constants/quality-layer.constant.ts
+++ b/apps/media/src/sfu/constants/quality-layer.constant.ts
@@ -1,0 +1,11 @@
+export const QUALITY = {
+  LOW: '480p',
+  MID: '720p',
+  HIGH: '1080p',
+};
+
+export const QUALITY_LAYER = {
+  [QUALITY.LOW]: 0,
+  [QUALITY.MID]: 1,
+  [QUALITY.HIGH]: 2,
+};

--- a/apps/media/src/sfu/dto/set-video-quality.dto.ts
+++ b/apps/media/src/sfu/dto/set-video-quality.dto.ts
@@ -1,0 +1,4 @@
+export class SetVideoQualityDto {
+  transportId: string;
+  quality: '480p' | '720p' | '1080p';
+}

--- a/apps/media/src/sfu/services/consumer.service.ts
+++ b/apps/media/src/sfu/services/consumer.service.ts
@@ -68,7 +68,7 @@ export class ConsumerService {
 
     const consumers = this.consumers.get(transportId);
     const videoConsumer = consumers.find(consumer => consumer.kind === 'video');
-    console.log(videoConsumer);
+
     videoConsumer.setPreferredLayers({
       spatialLayer: QUALITY_LAYER[quality],
       temporalLayer: 2,

--- a/apps/media/src/sfu/services/consumer.service.ts
+++ b/apps/media/src/sfu/services/consumer.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as mediasoup from 'mediasoup';
+import { SetVideoQualityDto } from '../dto/set-video-quality.dto';
+import { QUALITY, QUALITY_LAYER } from '../constants/quality-layer.constant';
 @Injectable()
 export class ConsumerService {
   private consumers = new Map<string, mediasoup.types.Consumer[]>();
@@ -16,6 +18,10 @@ export class ConsumerService {
           producerId: producer.id,
           rtpCapabilities,
           paused: false,
+          preferredLayers: {
+            spatialLayer: QUALITY_LAYER[QUALITY.MID], // 0,1,2 순으로 480p,720p,1080p. 기본값은 중간인 720p로 시작.
+            temporalLayer: 2, // fps: 0,1,2순으로 기본 fps의 1/4, 1/2, 1 로 들어감.
+          },
         });
         this.setUpConsumerListeners(consumer, transport.id);
         this.logger.log(`Consumer created: ${consumer.id}`);
@@ -55,5 +61,17 @@ export class ConsumerService {
       }
       this.logger.log(`Consumer closed: ${consumerId}`);
     }
+  }
+
+  setConsumerBitrate(params: SetVideoQualityDto) {
+    const { transportId, quality } = params;
+
+    const consumers = this.consumers.get(transportId);
+    const videoConsumer = consumers.find(consumer => consumer.kind === 'video');
+    console.log(videoConsumer);
+    videoConsumer.setPreferredLayers({
+      spatialLayer: QUALITY_LAYER[quality],
+      temporalLayer: 2,
+    });
   }
 }

--- a/apps/media/src/sfu/services/record.service.ts
+++ b/apps/media/src/sfu/services/record.service.ts
@@ -24,6 +24,10 @@ export class RecordService {
       producerId: producer.id,
       rtpCapabilities,
       paused: true,
+      preferredLayers: {
+        spatialLayer: 2,
+        temporalLayer: 2,
+      },
     });
 
     setTimeout(async () => {
@@ -55,12 +59,12 @@ export class RecordService {
 
   private setUpRecordTransportListeners(recordTransport: mediasoup.types.Transport, port: number, roomId: string) {
     recordTransport.on('routerclose', async () => {
-      await this.httpService
-        .post(`${this.configService.get('RECORD_SERVER_URL')}/close`, {
+      await lastValueFrom(
+        this.httpService.post(`${this.configService.get('RECORD_SERVER_URL')}/close`, {
           port,
           roomId,
-        })
-        .toPromise();
+        }),
+      );
       recordTransport.close();
     });
   }

--- a/apps/media/src/sfu/sfu.gateway.ts
+++ b/apps/media/src/sfu/sfu.gateway.ts
@@ -7,6 +7,7 @@ import { CreateConsumerDto } from './dto/create-consumer.dto';
 import { CreateTransportDto } from './dto/create-transport.dto';
 import { UseFilters } from '@nestjs/common';
 import { WebSocketExceptionFilter } from 'src/common/filter/webSocketException.filter';
+import { SetVideoQualityDto } from './dto/set-video-quality.dto';
 
 @WebSocketGateway({ cors: { origin: '*', methods: ['GET', 'POST'] } })
 @UseFilters(WebSocketExceptionFilter)
@@ -93,6 +94,12 @@ export class SfuGateway {
     } catch (error) {
       return error;
     }
+  }
+
+  //시청 종료
+  @SubscribeMessage('setVideoQuality')
+  handleVideoQuality(@MessageBody() params: SetVideoQualityDto) {
+    this.sfuService.setVideoQuality(params);
   }
 
   async handleDisconnect(client: Socket) {

--- a/apps/media/src/sfu/sfu.service.ts
+++ b/apps/media/src/sfu/sfu.service.ts
@@ -13,6 +13,7 @@ import { BroadcastService } from '../broadcast/broadcast.service';
 import { CreateBroadcastDto } from '../broadcast/dto/createBroadcast.dto';
 import { ClientService } from './services/client.service';
 import { RecordService } from './services/record.service';
+import { SetVideoQualityDto } from './dto/set-video-quality.dto';
 
 @Injectable()
 export class SfuService {
@@ -106,5 +107,9 @@ export class SfuService {
       const data = this.clientService.getClientTransport(clientId);
       await this.leaveBroadcast(data.roomId, data.transportId);
     }
+  }
+
+  setVideoQuality(params: SetVideoQualityDto) {
+    this.consumerService.setConsumerBitrate(params);
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #37 

## ✨ 구현 기능 명세
- consumer service 화질 조정 함수 구현
- sfu gateway 화질 조정 이벤트 구현
- plainTransport consumer 화질 고화질로 설정
 
## 🎁 PR Point
- 클라이언트 코드가 완료되면 클라이언트 쪽에서 encoding 설정을 해주어야 합니다.
- 클라이언트 측에서 해상도와 bitrate 설정이 더 중요하게 작용할 것 같습니다.

## 😭 어려웠던 점
- 해상도, 비트레이트, 프레임 등등 영상공부를 해야하는게 어려웠습니다.