### PR TITLE
[Feat] 기존 방송 제목 변경 api에 jwtguard 로직 추가

### DIFF
--- a/apps/api/src/broadcast/broadcast.controller.ts
+++ b/apps/api/src/broadcast/broadcast.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query, UseGuards } from '@nestjs/common';
 import { BroadcastService } from './broadcast.service';
 import { SuccessStatus } from '../common/responses/bases/successStatus';
 import { BroadcastListResponseDto } from './dto/broadcast-list-response.dto';
@@ -14,6 +14,9 @@ import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
 import { BroadcastSearchResponseDto } from './dto/broadcast-search-response.dto';
 import { FieldEnum } from 'src/member/enum/field.enum';
 import { CustomException } from 'src/common/responses/exceptions/custom.exception';
+import { JWTAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { UserReq } from 'src/common/decorators/user-req.decorator';
+import { Member } from 'src/member/member.entity';
 
 @Controller('v1/broadcasts')
 export class BroadcastController {
@@ -45,20 +48,16 @@ export class BroadcastController {
     return BroadcastInfoResponseDto.from(broadcast);
   }
 
-  // TODO: 유저 기능 추가 후 유저의 방송 찾는 로직 구현 필요
   @Patch('/title')
-  // @UseGuards(JwtAuthGuard)
+  @UseGuards(JWTAuthGuard)
   @ApiTags(SwaggerTag.BROADCAST)
   @ApiOperation({ summary: '방송 제목 수정' })
   @ApiBody({ type: UpdateBroadcastTitleDto })
   @ApiSuccessResponse(SuccessStatus.OK(null))
   @ApiErrorResponse(400, ErrorStatus.BROADCAST_NOT_FOUND)
   @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
-  async updateTitle(
-    // @Request() req,
-    @Body() updateBroadcastTitleDto: UpdateBroadcastTitleDto,
-  ) {
-    await this.broadcastService.updateTitle(null, updateBroadcastTitleDto);
+  async updateTitle(@UserReq() member: Member, @Body() updateBroadcastTitleDto: UpdateBroadcastTitleDto) {
+    await this.broadcastService.updateTitle(member.id, updateBroadcastTitleDto);
 
     return SuccessStatus.OK(null, '제목 수정이 완료 되었습니다.');
   }

--- a/apps/api/src/broadcast/broadcast.service.ts
+++ b/apps/api/src/broadcast/broadcast.service.ts
@@ -41,17 +41,10 @@ export class BroadcastService {
   }
 
   async updateTitle(userId: number, { title: broadcastTitle }: UpdateBroadcastTitleDto) {
-    // 임시 broadcastId로 사용
-    const tempBroadcastId = '1';
     const broadcast = await this.broadcastRepository.findOne({
-      where: { id: tempBroadcastId },
+      where: { member: { id: userId } },
+      relations: ['member'],
     });
-
-    // TODO: 현재 userId로 넘어오는 값이 null 임
-    // const broadcast = await this.broadcastRepository.findOne({
-    //   where: { member: { id: userId } },
-    //   relations: ['member'],
-    // });
 
     if (!broadcast) {
       throw new CustomException(ErrorStatus.BROADCAST_NOT_FOUND);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
- #264 

## ✨ 구현 기능 명세
- 방송 제목 변경 api에 jwt guard 로직 추가

## 🎁 PR Point
### 결과화면 
![image](https://github.com/user-attachments/assets/deb54f44-d057-42ce-b11b-c06557675b18)


## 😭 어려웠던 점
