### PR TITLE
[Feat] 방송 리스트 무한 스크롤 페이지네이션 구현

### DIFF
--- a/apps/api/src/broadcast/broadcast.controller.ts
+++ b/apps/api/src/broadcast/broadcast.controller.ts
@@ -17,6 +17,7 @@ import { CustomException } from 'src/common/responses/exceptions/custom.exceptio
 import { JWTAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { UserReq } from 'src/common/decorators/user-req.decorator';
 import { Member } from 'src/member/member.entity';
+import { BroadcastListDto } from './dto/broadcast-list.dto';
 
 @Controller('v1/broadcasts')
 export class BroadcastController {
@@ -27,13 +28,16 @@ export class BroadcastController {
   @ApiOperation({ summary: '방송 리스트 조회' })
   @ApiSuccessResponse(SuccessStatus.OK(BroadcastListResponseDto), BroadcastListResponseDto)
   @ApiErrorResponse(500, ErrorStatus.INTERNAL_SERVER_ERROR)
-  async getAllWithFilter(@Query('field') field: FieldEnum) {
+  async getAllWithFilterAndPagination(@Query() queries: BroadcastListDto) {
+    const { field } = queries;
+
     if (field && !Object.values(FieldEnum).includes(field as FieldEnum)) {
       throw new CustomException(ErrorStatus.INVALID_FIELD);
     }
 
-    const broadcasts = await this.broadcastService.getAllWithFilter(field);
-    return BroadcastListResponseDto.fromList(broadcasts);
+    const { broadcasts, nextCursor } = await this.broadcastService.getAllWithFilterAndPagination(queries);
+
+    return BroadcastListResponseDto.from(broadcasts, nextCursor);
   }
 
   @Get('/:broadcastId/info')

--- a/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
@@ -1,28 +1,27 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { FieldEnum } from '../../member/enum/field.enum';
 import { Broadcast } from '../broadcast.entity';
-
-export class BroadcastListResponseDto {
-  @ApiProperty({ example: '73ebe906-0897-478d-b7c6-42f5ba7abc0a' })
+class BroadcastDto {
+  @ApiProperty()
   broadcastId: string;
 
-  @ApiProperty({ example: '오늘 코딩 켠왕 간다' })
+  @ApiProperty()
   broadcastTitle: string;
 
-  @ApiProperty({ example: 'thunbnail 주소 src' })
+  @ApiProperty()
   thumbnail: string;
 
-  @ApiProperty({ example: 'J219' })
+  @ApiProperty()
   camperId: string;
 
-  @ApiProperty({ example: 'profile Image 주소 src' })
+  @ApiProperty()
   profileImage: string;
 
-  @ApiProperty({ example: 'WEB' })
+  @ApiProperty()
   field: FieldEnum;
 
-  static from(broadcast: Broadcast): BroadcastListResponseDto {
-    const dto = new BroadcastListResponseDto();
+  static from(broadcast: Broadcast) {
+    const dto = new BroadcastDto();
     dto.broadcastId = broadcast.id;
     dto.broadcastTitle = broadcast.title;
     dto.thumbnail = broadcast.thumbnail;
@@ -32,7 +31,34 @@ export class BroadcastListResponseDto {
     return dto;
   }
 
-  static fromList(broadcasts: Broadcast[]): BroadcastListResponseDto[] {
+  static fromList(broadcasts: Broadcast[]) {
     return broadcasts.map(broadcast => this.from(broadcast));
+  }
+}
+
+export class BroadcastListResponseDto {
+  @ApiProperty({
+    type: BroadcastDto,
+    example: [
+      {
+        id: '73ebe906-0897-478d-b7c6-42f5ba7abc0a',
+        title: '오늘 코딩 켠왕 간다',
+        thumbnail: 'thumbnail.jpg',
+        camperId: 'J219',
+        profileImage: 'profile.jpg',
+        field: 'WEB',
+      },
+    ],
+  })
+  broadcasts: BroadcastDto[];
+
+  @ApiProperty({ example: '73ebe906-0897-478d-b7c6-42f5ba7abc0a' })
+  nextCursor: string;
+
+  static from(broadcasts: Broadcast[], nextCursor: string) {
+    const dto = new BroadcastListResponseDto();
+    dto.broadcasts = BroadcastDto.fromList(broadcasts);
+    dto.nextCursor = nextCursor;
+    return dto;
   }
 }

--- a/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-list-response.dto.ts
@@ -39,16 +39,7 @@ class BroadcastDto {
 export class BroadcastListResponseDto {
   @ApiProperty({
     type: BroadcastDto,
-    example: [
-      {
-        id: '73ebe906-0897-478d-b7c6-42f5ba7abc0a',
-        title: '오늘 코딩 켠왕 간다',
-        thumbnail: 'thumbnail.jpg',
-        camperId: 'J219',
-        profileImage: 'profile.jpg',
-        field: 'WEB',
-      },
-    ],
+    isArray: true,
   })
   broadcasts: BroadcastDto[];
 

--- a/apps/api/src/broadcast/dto/broadcast-list.dto.ts
+++ b/apps/api/src/broadcast/dto/broadcast-list.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { FieldEnum } from '../../member/enum/field.enum';
+
+export class BroadcastListDto {
+  @ApiProperty({ example: 'WEB' })
+  field?: FieldEnum = null;
+
+  @ApiProperty({ example: '73ebe906-0897-478d-b7c6-42f5ba7abc0a' })
+  cursor?: string = null;
+
+  @ApiProperty({ example: 12 })
+  limit: number = 12;
+}

--- a/apps/client/src/pages/Home/index.tsx
+++ b/apps/client/src/pages/Home/index.tsx
@@ -2,11 +2,11 @@ import LiveList from '@pages/Home/LiveList';
 import LoadingCharacter from '@components/LoadingCharacter';
 import ErrorCharacter from '@components/ErrorCharacter';
 import { useAPI } from '@hooks/useAPI';
-import { LivePreviewInfo } from '@/types/homeTypes';
+import { LivePreviewListInfo } from '@/types/homeTypes';
 import { useEffect, useState } from 'react';
 
 export default function Home() {
-  const { data: liveList, isLoading, error } = useAPI<LivePreviewInfo[]>({ url: '/v1/broadcasts' });
+  const { data: liveListInfo, isLoading, error } = useAPI<LivePreviewListInfo>({ url: '/v1/broadcasts' });
   const [showLoading, setShowLoading] = useState(false);
 
   useEffect(() => {
@@ -27,8 +27,8 @@ export default function Home() {
         <div className="flex justify-center items-center flex-1">
           <LoadingCharacter />
         </div>
-      ) : liveList && liveList.length > 0 ? (
-        <LiveList liveList={liveList} />
+      ) : liveListInfo?.broadcasts && liveListInfo.broadcasts.length > 0 ? (
+        <LiveList liveList={liveListInfo.broadcasts} />
       ) : (
         <div className="h-full flex items-center">방송 중인 캠퍼가 없습니다.</div>
       )}

--- a/apps/client/src/types/homeTypes.ts
+++ b/apps/client/src/types/homeTypes.ts
@@ -1,8 +1,13 @@
-export interface LivePreviewInfo {
+interface LivePreviewInfo {
   broadcastId: string;
   broadcastTitle: string;
   camperId: string;
   profileImage: string;
   thumbnail: string;
   field: 'WEB' | 'AND' | 'IOS';
+}
+
+export interface LivePreviewListInfo {
+  broadcasts: LivePreviewInfo[];
+  nextCursor: string | null;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #260 

## ✨ 구현 기능 명세
- 커서 기반 페이지네이션 구현
- 응답 데이터 변경으로 인한 프론트엔드 코드 수정

## 🎁 PR Point
- offset(page) 기반 페이지 네이션이 아닌 커서 기반 페이지네이션으로 구현하였습니다!

### offset(page) 기반 페이지네이션의 문제점
- 예를들어 초반에 1~10번 데이터를 가져옴.
- 무한스크롤 도중에 1 ~ 10번 데이터중 하나가 삭제되는 상황이 발생한다면 다음 페이지에서 11 ~ 20번을 가져와야하지만 12 ~ 21번을 가져와 중간에 데이터가 유실되는 상황 발생.
- 무한 스크롤 도중에 1 ~ 10번 데이터중 데이터가 추가되는 상황이 발생한다면 다음 페이지에서 10번 ~ 19번을 가져와 데이터를 중복으로 보여주는 상황 발생. (일반 페이지 변경 방식이면 상관없지만 무한스크롤의 경우 같은 데이터가 두번 보여짐)
- 또한, 데이터 조회 성능 관점에서도 offset 방식은 31 ~ 40번째 데이터를 가져온다면 1 ~ 40 데이터를 다 탐색하는 단점이 있음.

### 커서기반 페이지네이션
- 클라이언트에서 cursor(페이지네이션 기준 데이터)와 limit query param을 전달
- db에서 cursor에 해당하는 데이터의 다음 데이터부터 limit 갯수만큼 조회 후 반환
- 다음 페이지네이션에 사용될 nextCursor도 반환. 페이지의 끝이라면 nextCursor null 전달.
- 클라이언트는 nextCursor을 다음 페이지네이션에 이용. nextCursor가 null이면 무한스크롤 중지.

### 프론트엔드 필독!!!!!
- 방송 리스트 조회 api의 응답 데이터가 수정되어 메인페이지가 아무것도 보이지 않아 일단 데이터가 보이도록 프론트엔드 코드를 수정했습니다. 후에 무한스크롤 반영시에 수정된 코드에서 더 디벨롭해서 사용하시면 될 것 같습니다.
- 메인페이지 처음 조회할때 cursor : null
- 스크롤 하면서 조회할때 cursor : 이전에 반환했던 nextCursor값
- nextCursor가 null이 들어오면 다음 데이터가 없다는 뜻이니 무한스크롤 중지
- 자세한 사항은 swagger 명세서 참고

## 😭 어려웠던 점
- offset으로 구현하다가 이상한 점을 느껴서 엎었다..