### PR TITLE
[Fix] 화면 공유 Revert된 내용 복구 & 마이크 on/off 해결

### DIFF
--- a/apps/client/src/hooks/useConsumer.ts
+++ b/apps/client/src/hooks/useConsumer.ts
@@ -39,6 +39,7 @@ export interface CreateConsumerResponse {
 
 export const useConsumer = ({ socket, device, roomId, transportInfo, isConnected }: UseConsumerProps) => {
   const transport = useRef<Transport | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [mediastream, setMediastream] = useState<MediaStream | null>(null);
 
@@ -167,6 +168,7 @@ export const useConsumer = ({ socket, device, roomId, transportInfo, isConnected
           transport: transport.current,
         }),
       )
+      .then(() => setIsLoading(false))
       .catch(err => setError(err instanceof Error ? err : new Error('Consumer initialization failed')));
 
     return () => {
@@ -182,5 +184,6 @@ export const useConsumer = ({ socket, device, roomId, transportInfo, isConnected
     transport: transport.current,
     mediastream,
     error,
+    isLoading,
   };
 };

--- a/apps/client/src/hooks/useMediaControls.ts
+++ b/apps/client/src/hooks/useMediaControls.ts
@@ -41,7 +41,7 @@ export const useMediaControls = (mediaStream: MediaStream | null): MediaControls
     if (!mediaStream) return;
     const audioTrack = mediaStream.getAudioTracks()[0];
     if (audioTrack) {
-      audioTrack.enabled = !audioTrack.enabled;
+      // audioTrack.enabled = !audioTrack.enabled;
       setState(prev => ({ ...prev, isAudioEnabled: audioTrack.enabled }));
     }
   };

--- a/apps/client/src/hooks/useMediaStream.ts
+++ b/apps/client/src/hooks/useMediaStream.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
 export const useMediaStream = () => {
-  const videoRef = useRef<HTMLVideoElement>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
   const [mediaStreamError, setMediaStreamError] = useState<Error | null>(null);
   const [isMediastreamReady, setIsMediastreamReady] = useState(false);
@@ -16,9 +15,6 @@ export const useMediaStream = () => {
       const mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
       setIsMediastreamReady(true);
 
-      if (videoRef.current) {
-        videoRef.current.srcObject = mediaStream;
-      }
       mediaStreamRef.current = mediaStream;
     } catch (err) {
       setMediaStreamError(err instanceof Error ? err : new Error('유저 미디어(비디오, 오디오) 갖고 오기 실패'));
@@ -26,15 +22,11 @@ export const useMediaStream = () => {
   };
 
   useEffect(() => {
-    const videoElement = videoRef.current;
     initializeStream();
 
     return () => {
       if (mediaStreamRef.current) {
         mediaStreamRef.current.getTracks().forEach(track => track.stop());
-      }
-      if (videoElement) {
-        videoElement.srcObject = null;
       }
     };
   }, []);
@@ -43,6 +35,5 @@ export const useMediaStream = () => {
     mediaStream: mediaStreamRef.current,
     mediaStreamError,
     isMediastreamReady,
-    videoRef,
   };
 };

--- a/apps/client/src/hooks/useProducer.ts
+++ b/apps/client/src/hooks/useProducer.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Transport, Device } from 'mediasoup-client/lib/types';
-import { ConnectTransportResponse, Tracks, TransportInfo } from '../types/mediasoupTypes';
+import { ConnectTransportResponse, Tracks, TransportInfo } from '@/types/mediasoupTypes';
 import { Socket } from 'socket.io-client';
 import { checkDependencies } from '@/utils/utils';
 
@@ -114,8 +114,11 @@ export const useProducer = ({
           );
         });
 
-        (Object.keys(tracks) as Array<keyof Tracks>).forEach(track => {
-          transport.current!.produce({ track: tracks[track] });
+        (Object.keys(tracks) as Array<keyof Tracks>).forEach(kind => {
+          if (tracks[kind]) {
+            transport.current!.produce({ track: tracks[kind] });
+            console.log('프로듀스 생성');
+          }
         });
       });
     } catch (err) {
@@ -139,7 +142,7 @@ export const useProducer = ({
         transport.current = null;
       }
     };
-  }, [socket, device, roomId, transportInfo, isMediastreamReady]);
+  }, [socket, device, roomId, transportInfo, isStreamReady]);
 
   return {
     transport: transport.current,

--- a/apps/client/src/hooks/useScreenShare.ts
+++ b/apps/client/src/hooks/useScreenShare.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useScreenShare = () => {
+  const screenStreamRef = useRef<MediaStream | null>(null);
+  const [screenShareError, setScreenShareError] = useState<Error | null>(null);
+  const [isScreenSharing, setIsScreenSharing] = useState(false);
+
+  const startScreenShare = async () => {
+    try {
+      const options = {
+        video: true,
+        audio: true,
+      };
+
+      const mediaStream = await navigator.mediaDevices.getDisplayMedia(options);
+      setIsScreenSharing(true);
+      screenStreamRef.current = mediaStream;
+    } catch (err) {
+      if (err instanceof Error) {
+        if (err.name !== 'NotAllowedError') {
+          setScreenShareError(err);
+        }
+      } else {
+        setScreenShareError(new Error('화면 공유 실패'));
+      }
+    }
+  };
+
+  const endScreenShare = async () => {
+    if (screenStreamRef.current) {
+      screenStreamRef.current.getTracks().forEach(track => track.stop());
+    }
+    setIsScreenSharing(false);
+  };
+
+  const toggleScreenShare = () => {
+    if (isScreenSharing) {
+      endScreenShare();
+    } else {
+      startScreenShare();
+    }
+  };
+
+  useEffect(() => {
+    if (isScreenSharing) {
+      startScreenShare();
+      setIsScreenSharing(false);
+    }
+
+    return () => {
+      endScreenShare();
+    };
+  }, []);
+
+  return {
+    screenStream: screenStreamRef.current,
+    isScreenSharing,
+    screenShareError,
+    toggleScreenShare,
+  };
+};
+
+export default useScreenShare;

--- a/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
+++ b/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
@@ -1,7 +1,7 @@
 import { Tracks } from '@/types/mediasoupTypes';
 import { useEffect, useRef } from 'react';
 
-interface VideoPlayerProps {
+interface BroadcastPlayerProps {
   mediaStream: MediaStream | null;
   screenStream: MediaStream | null;
   isVideoEnabled: boolean;
@@ -9,10 +9,9 @@ interface VideoPlayerProps {
   isStreamReady: boolean;
   setIsStreamReady: (ready: boolean) => void;
   tracksRef: React.MutableRefObject<Tracks>;
-  isAudioEnabled: boolean;
 }
 
-function VideoPlayer({
+function BroadcastPlayer({
   mediaStream,
   screenStream,
   isVideoEnabled,
@@ -20,8 +19,7 @@ function VideoPlayer({
   isStreamReady,
   setIsStreamReady,
   tracksRef,
-  isAudioEnabled,
-}: VideoPlayerProps) {
+}: BroadcastPlayerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const screenShareRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -32,7 +30,7 @@ function VideoPlayer({
       videoRef.current.srcObject = mediaStream;
     }
     tracksRef.current['mediaAudio'] = mediaStream?.getAudioTracks()[0];
-  }, [mediaStream]);
+  }, [mediaStream, tracksRef.current]);
 
   // 화면 공유 스트림 설정
   useEffect(() => {
@@ -40,7 +38,7 @@ function VideoPlayer({
       screenShareRef.current.srcObject = screenStream;
     }
     tracksRef.current['screenAudio'] = screenStream?.getAudioTracks()[0];
-  }, [isScreenSharing, screenStream]);
+  }, [isScreenSharing, screenStream, tracksRef.current]);
 
   // 미디어스트림 캔버스에 넣기
   useEffect(() => {
@@ -56,8 +54,8 @@ function VideoPlayer({
     const draw = () => {
       context.clearRect(0, 0, canvas.width, canvas.height);
 
-      // 화면 공유 on
       if (isScreenSharing && screenShareRef.current) {
+        // 화면 공유 on
         context.drawImage(screenShareRef.current, 0, 0, canvas.width, canvas.height);
         // 캠 on
         if (isVideoEnabled && videoRef.current) {
@@ -90,7 +88,7 @@ function VideoPlayer({
         startDrawing();
       }
     }
-  }, [isVideoEnabled, isAudioEnabled, isScreenSharing, mediaStream, screenStream, isStreamReady, setIsStreamReady]);
+  }, [isVideoEnabled, isScreenSharing, mediaStream, screenStream, isStreamReady]);
 
   return (
     <div className="relative w-full max-h-[310px] aspect-video">
@@ -112,4 +110,4 @@ function VideoPlayer({
   );
 }
 
-export default VideoPlayer;
+export default BroadcastPlayer;

--- a/apps/client/src/pages/Broadcast/index.tsx
+++ b/apps/client/src/pages/Broadcast/index.tsx
@@ -11,7 +11,7 @@ import { MicrophoneOffIcon, MicrophoneOnIcon, VideoOffIcon, VideoOnIcon, Monitor
 import { Button } from '@components/ui/button';
 import { useEffect, useRef, useState } from 'react';
 import useScreenShare from '@/hooks/useScreenShare';
-import VideoPlayer from './BroadcastPlayer';
+import BroadcastPlayer from './BroadcastPlayer';
 import { Tracks } from '@/types/mediasoupTypes';
 
 const mediaServerUrl = import.meta.env.VITE_MEDIASERVER_URL;
@@ -64,6 +64,7 @@ function Broadcast() {
   useEffect(() => {
     window.addEventListener('beforeunload', stopBroadcast);
 
+    tracksRef.current['mediaAudio'] = mediaStream?.getAudioTracks()[0];
     return () => {
       window.removeEventListener('beforeunload', stopBroadcast);
     };
@@ -78,13 +79,19 @@ function Broadcast() {
     setTitle(newTitle);
   };
 
-  if (socketError || roomError || transportError) {
+  if (socketError || roomError || transportError || screenShareError) {
     return (
       <div className="flex h-full justify-center items-center">
         <ErrorCharacter
           size={300}
           message={`방송 연결 중 에러가 발생했습니다: ${
-            socketError ? socketError.message : roomError ? roomError.message : transportError?.message
+            socketError
+              ? socketError.message
+              : roomError
+              ? roomError.message
+              : transportError
+              ? transportError.message
+              : screenShareError?.message
           }`}
         />
       </div>
@@ -101,7 +108,7 @@ function Broadcast() {
         </>
       ) : (
         <>
-          <VideoPlayer
+          <BroadcastPlayer
             mediaStream={mediaStream}
             screenStream={screenStream}
             isVideoEnabled={isVideoEnabled}
@@ -109,7 +116,6 @@ function Broadcast() {
             isStreamReady={isStreamReady}
             setIsStreamReady={setIsStreamReady}
             tracksRef={tracksRef}
-            isAudioEnabled={isAudioEnabled}
           />
           <div className="w-full">
             <BroadcastTitle currentTitle={title} onTitleChange={handleBroadcastTitle} />
@@ -120,7 +126,7 @@ function Broadcast() {
               <div className="flex items-center gap-4">
                 <button onClick={toggleVideo}>{isVideoEnabled ? <VideoOnIcon /> : <VideoOffIcon />}</button>
                 <button onClick={toggleAudio}>{isAudioEnabled ? <MicrophoneOnIcon /> : <MicrophoneOffIcon />}</button>
-                <button>
+                <button onClick={toggleScreenShare}>
                   <MonitorShareIcon />
                 </button>
               </div>

--- a/apps/client/src/pages/Broadcast/index.tsx
+++ b/apps/client/src/pages/Broadcast/index.tsx
@@ -30,7 +30,11 @@ function Broadcast() {
   const { socket, isConnected, socketError } = useSocket(mediaServerUrl);
   const { roomId, roomError } = useRoom(socket, isConnected);
   const { transportInfo, device, transportError } = useTransport({ socket, roomId, isProducer: true });
-  const { transport, error: mediasoupError } = useProducer({
+  const {
+    transport,
+    error: mediasoupError,
+    producers,
+  } = useProducer({
     socket,
     tracks: tracksRef.current,
     isStreamReady,
@@ -79,6 +83,18 @@ function Broadcast() {
     setTitle(newTitle);
   };
 
+  const playPauseAudio = () => {
+    if (isAudioEnabled) {
+      producers.get('mediaAudio')?.pause();
+      if (tracksRef.current.mediaAudio) tracksRef.current.mediaAudio.enabled = false;
+      console.log('오디오 pause');
+    } else {
+      producers.get('mediaAudio')?.resume();
+      if (tracksRef.current.mediaAudio) tracksRef.current.mediaAudio.enabled = true;
+      console.log('오디오 resume');
+    }
+  };
+
   if (socketError || roomError || transportError || screenShareError) {
     return (
       <div className="flex h-full justify-center items-center">
@@ -125,7 +141,14 @@ function Broadcast() {
               </Button>
               <div className="flex items-center gap-4">
                 <button onClick={toggleVideo}>{isVideoEnabled ? <VideoOnIcon /> : <VideoOffIcon />}</button>
-                <button onClick={toggleAudio}>{isAudioEnabled ? <MicrophoneOnIcon /> : <MicrophoneOffIcon />}</button>
+                <button
+                  onClick={() => {
+                    toggleAudio();
+                    playPauseAudio();
+                  }}
+                >
+                  {isAudioEnabled ? <MicrophoneOnIcon /> : <MicrophoneOffIcon />}
+                </button>
                 <button onClick={toggleScreenShare}>
                   <MonitorShareIcon />
                 </button>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #274 

## ✨ 구현 기능 명세

- Revert된 화면 공유 PR 내용 복구
- 마이크 on/off 안되던 문제 해결

## 🎁 PR Point

### 음성 on/off 문제 해결

- 문제 상황

방송 송출쪽에서 마이크 on/off 버튼을 눌러도 시청하는 쪽에 여전히 소리가 전송되는 문제가 있었다. 

- 해결

초기에 트랙별로 produce를 할 때 producer를 받는다. 이 producer에서 pause와 play 메서드를 이용하여 해결했다. 마이크 off 버튼을 누르면 producer를 pause하고, 마이크 on 버튼을 누르면 producer를 resume한다.

## 😭 어려웠던 점

계속 getUserMedia()로 갖고 온 미디어 스트림 중 오디오 트랙 enabled 상태를 제어하기도 하고, createProducer를 할 때 넘기는 트랙 객체 중 mediaAudio의 오디오를 enabled도 해보고, 오디오 트랙 자체를 stop하는 등 다양한 시도를 했지만 다 되지 않아서 오랜 시간이 걸렸다.

special thanks to 희선님....😂