### PR TITLE
[Feat] socket과 axios 요청 시 헤더에 accessToken 넣기

### DIFF
--- a/apps/client/src/hooks/useSocket.ts
+++ b/apps/client/src/hooks/useSocket.ts
@@ -17,6 +17,7 @@ export const useSocket = (url: string) => {
   const [isConnected, setIsConnected] = useState(false);
 
   useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
     if (socketRef.current?.connected) return;
     const socket = io(url, {
       withCredentials: true,
@@ -26,6 +27,9 @@ export const useSocket = (url: string) => {
       reconnectionAttempts: 5, // 최대 재연결 시도 횟수
       reconnectionDelay: 1000,
       path: '/socket.io',
+      extraHeaders: {
+        Authorization: accessToken ? `Bearer ${accessToken}` : '',
+      },
     });
     socketRef.current = socket;
 

--- a/apps/client/src/services/axios.ts
+++ b/apps/client/src/services/axios.ts
@@ -9,4 +9,17 @@ const axiosInstance = axios.create({
   timeout: 5000,
 });
 
+axiosInstance.interceptors.request.use(
+  config => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  error => {
+    return Promise.reject(error);
+  },
+);
+
 export default axiosInstance;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #29

## ✨ 구현 기능 명세

- socket과 axios 요청 시 헤더에 accessToken 넣기

## 🎁 PR Point

### socket

```typescript
const socket = io(url, {
  withCredentials: true,
  transports: ['websocket', 'polling'],
  timeout: 10000, // 10초 동안 응답 못 받으면 연결 끊음
  reconnection: true, // 재연결 시도 활성화
  reconnectionAttempts: 5, // 최대 재연결 시도 횟수
  reconnectionDelay: 1000,
  path: '/socket.io',
  extraHeaders: {
    Authorization: accessToken ? `Bearer ${accessToken}` : '',
  },
});
```

### axios

```typescript
const axiosInstance = axios.create({
  baseURL: baseUrl,
  headers: { 'Content-Type': 'application/json' },
  withCredentials: true,
  timeout: 5000,
});

axiosInstance.interceptors.request.use(
  config => {
    const accessToken = localStorage.getItem('accessToken');
    if (accessToken) {
      config.headers.Authorization = `Bearer ${accessToken}`;
    }
    return config;
  },
  error => {
    return Promise.reject(error);
  },
);
```

interceptor 이용해서 요청 보내기 전에 accessToken이 있는지 확인하여 있다면 헤더에 추가

### 참고 자료 

- [[React] Axios 인스턴스 - 헤더에 acessToken 넣기](https://hisoit.tistory.com/103)

## 😭 어려웠던 점
