### PR TITLE
[Fix] 소켓에 accessToken 전달하는 방법 수정

### DIFF
--- a/apps/client/src/hooks/useSocket.ts
+++ b/apps/client/src/hooks/useSocket.ts
@@ -27,8 +27,8 @@ export const useSocket = (url: string) => {
       reconnectionAttempts: 5, // 최대 재연결 시도 횟수
       reconnectionDelay: 1000,
       path: '/socket.io',
-      extraHeaders: {
-        Authorization: accessToken ? `Bearer ${accessToken}` : '',
+      auth: {
+        accessToken: accessToken ? `Bearer ${accessToken}` : '',
       },
     });
     socketRef.current = socket;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #286 

## ✨ 구현 기능 명세

-  소켓에 accessToken 전달하는 방법 수정

## 🎁 PR Point

```typescript
const socket = io(url, {
  withCredentials: true,
  transports: ['websocket', 'polling'],
  timeout: 10000, // 10초 동안 응답 못 받으면 연결 끊음
  reconnection: true, // 재연결 시도 활성화
  reconnectionAttempts: 5, // 최대 재연결 시도 횟수
  reconnectionDelay: 1000,
  path: '/socket.io',
  auth: {
    accessToken: accessToken ? `Bearer ${accessToken}` : '',
  },
});
```

auth로 accessToken 전달

## 😭 어려웠던 점

다시는 테스트 안하고 push하는 일은 없도록 하겠습니다....🤣