### PR TITLE
[Feat] 방송 화질 조정 기능 구현

### DIFF
--- a/apps/client/src/constants/videoOptions.ts
+++ b/apps/client/src/constants/videoOptions.ts
@@ -1,11 +1,11 @@
 export const ENCODING_OPTIONS = [
   { maxBitrate: 750000, scaleResolutionDownBy: 2, maxFramerate: 30 },
-  { maxBitrate: 1500000, scaleResolutionDownBy: 1.5, maxFramerate: 30 },
+  { maxBitrate: 2500000, scaleResolutionDownBy: 1.5, maxFramerate: 30 },
   { maxBitrate: 4000000, scaleResolutionDownBy: 1, maxFramerate: 30 },
 ];
 
 export const RESOLUTION_OPTIONS = {
-  high: { width: 1920, height: 1080, label: '1080p' },
-  medium: { width: 1280, height: 720, label: '720p' },
-  low: { width: 854, height: 480, label: '480p' },
+  high: { width: 1920, height: 1080 },
+  medium: { width: 1280, height: 720 },
+  low: { width: 854, height: 480 },
 };

--- a/apps/client/src/constants/videoOptions.ts
+++ b/apps/client/src/constants/videoOptions.ts
@@ -1,0 +1,11 @@
+export const ENCODING_OPTIONS = [
+  { maxBitrate: 750000, scaleResolutionDownBy: 2, maxFramerate: 30 },
+  { maxBitrate: 1500000, scaleResolutionDownBy: 1.5, maxFramerate: 30 },
+  { maxBitrate: 4000000, scaleResolutionDownBy: 1, maxFramerate: 30 },
+];
+
+export const RESOLUTION_OPTIONS = {
+  high: { width: 1920, height: 1080, label: '1080p' },
+  medium: { width: 1280, height: 720, label: '720p' },
+  low: { width: 854, height: 480, label: '480p' },
+};

--- a/apps/client/src/hooks/useProducer.ts
+++ b/apps/client/src/hooks/useProducer.ts
@@ -3,6 +3,7 @@ import { Transport, Device, Producer } from 'mediasoup-client/lib/types';
 import { ConnectTransportResponse, Tracks, TransportInfo } from '@/types/mediasoupTypes';
 import { Socket } from 'socket.io-client';
 import { checkDependencies } from '@/utils/utils';
+import { ENCODING_OPTIONS } from '@/constants/videoOptions';
 
 interface UseProducerProps {
   socket: Socket | null;
@@ -100,9 +101,19 @@ export const useProducer = ({
 
     (Object.keys(tracks) as Array<keyof Tracks>).forEach(kind => {
       if (tracks[kind]) {
-        console.log(kind, ':', tracks[kind]);
+        const producerConfig: Record<string, unknown> = {
+          track: tracks[kind],
+        };
+
+        if (kind === 'video') {
+          producerConfig['encodings'] = ENCODING_OPTIONS;
+          producerConfig['codecOptions'] = {
+            videoGoogleStartBitrate: 1000,
+          };
+        }
+        
         transport
-          .current!.produce({ track: tracks[kind] })
+          .current!.produce(producerConfig)
           .then(producer => setProducers(prev => new Map(prev).set(kind, producer)));
       }
     });

--- a/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
+++ b/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
@@ -64,26 +64,23 @@ function BroadcastPlayer({
         // 화면 비율 계산 및 적용
         const screenRatio = screenVideo.videoWidth / screenVideo.videoHeight;
         const canvasRatio = canvas.width / canvas.height;
-
-        let drawWidth = canvas.width;
-        let drawHeight = canvas.height;
-        let drawX = 0;
-        let drawY = 0;
+        const draw = { width: canvas.width, height: canvas.height, x: 0, y: 0 };
 
         if (screenRatio > canvasRatio) {
           // 화면이 더 넓은 경우
-          drawHeight = canvas.width / screenRatio;
-          drawY = (canvas.height - drawHeight) / 2;
+          draw.height = canvas.width / screenRatio;
+          draw.y = (canvas.height - draw.height) / 2;
         } else {
           // 화면이 더 좁은 경우
-          drawWidth = canvas.height * screenRatio;
-          drawX = (canvas.width - drawWidth) / 2;
+          draw.width = canvas.height * screenRatio;
+          console.log('width', canvas.height / screenRatio);
+          draw.x = (canvas.width - draw.height) / 2;
         }
 
         // 화면 공유 그리기
         context.fillStyle = '#000000';
         context.fillRect(0, 0, canvas.width, canvas.height);
-        context.drawImage(screenVideo, drawX, drawY, drawWidth, drawHeight);
+        context.drawImage(screenVideo, draw.x, draw.y, draw.width, draw.height);
 
         // 캠 on
         if (isVideoEnabled && videoRef.current) {

--- a/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
+++ b/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
@@ -1,3 +1,4 @@
+import { RESOLUTION_OPTIONS } from '@/constants/videoOptions';
 import { Tracks } from '@/types/mediasoupTypes';
 import { useEffect, useRef } from 'react';
 
@@ -45,11 +46,14 @@ function BroadcastPlayer({
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    canvas.width = 1280;
-    canvas.height = 720;
+    canvas.width = RESOLUTION_OPTIONS['high'].width;
+    canvas.height = RESOLUTION_OPTIONS['high'].height;
 
     const context = canvas.getContext('2d');
     if (!context) return;
+
+    context.imageSmoothingEnabled = true;
+    context.imageSmoothingQuality = 'high';
 
     const draw = () => {
       context.clearRect(0, 0, canvas.width, canvas.height);
@@ -102,8 +106,8 @@ function BroadcastPlayer({
       />
       <canvas
         ref={canvasRef}
-        width={1280}
-        height={720}
+        width={RESOLUTION_OPTIONS['high'].width}
+        height={RESOLUTION_OPTIONS['high'].height}
         className="absolute top-0 left-0 w-full h-full bg-surface-alt object-cover"
       />
     </div>

--- a/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
+++ b/apps/client/src/pages/Broadcast/BroadcastPlayer.tsx
@@ -59,8 +59,32 @@ function BroadcastPlayer({
       context.clearRect(0, 0, canvas.width, canvas.height);
 
       if (isScreenSharing && screenShareRef.current) {
+        const screenVideo = screenShareRef.current;
         // 화면 공유 on
-        context.drawImage(screenShareRef.current, 0, 0, canvas.width, canvas.height);
+        // 화면 비율 계산 및 적용
+        const screenRatio = screenVideo.videoWidth / screenVideo.videoHeight;
+        const canvasRatio = canvas.width / canvas.height;
+
+        let drawWidth = canvas.width;
+        let drawHeight = canvas.height;
+        let drawX = 0;
+        let drawY = 0;
+
+        if (screenRatio > canvasRatio) {
+          // 화면이 더 넓은 경우
+          drawHeight = canvas.width / screenRatio;
+          drawY = (canvas.height - drawHeight) / 2;
+        } else {
+          // 화면이 더 좁은 경우
+          drawWidth = canvas.height * screenRatio;
+          drawX = (canvas.width - drawWidth) / 2;
+        }
+
+        // 화면 공유 그리기
+        context.fillStyle = '#000000';
+        context.fillRect(0, 0, canvas.width, canvas.height);
+        context.drawImage(screenVideo, drawX, drawY, drawWidth, drawHeight);
+
         // 캠 on
         if (isVideoEnabled && videoRef.current) {
           const pipWidth = canvas.width / 4;

--- a/apps/client/src/pages/Live/LivePlayer.tsx
+++ b/apps/client/src/pages/Live/LivePlayer.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useRef, useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@components/ui/select';
 import { PlayIcon, PauseIcon, VolumeOffIcon, VolumeOnIcon, ExpandIcon } from '@/components/Icons';
+import { Socket } from 'socket.io-client';
 
-type VideoQuality = '480' | '720' | '1080';
+interface LivePlayerProps {
+  mediaStream: MediaStream | null;
+  socket: Socket | null;
+  transportId: string | undefined;
+}
 
-function LivePlayer({ mediaStream }: { mediaStream: MediaStream | null }) {
+type VideoQuality = '480p' | '720p' | '1080p';
+
+function LivePlayer({ mediaStream, socket, transportId }: LivePlayerProps) {
   const [isVideoEnabled, setIsVideoEnabled] = useState(true);
   const [isAudioEnabled, setIsAudioEnabled] = useState(false);
-  const [videoQuality, setVideoQuality] = useState<VideoQuality>('480');
+  const [videoQuality, setVideoQuality] = useState('720p');
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
@@ -42,6 +49,9 @@ function LivePlayer({ mediaStream }: { mediaStream: MediaStream | null }) {
   };
 
   const handleVideoQuality = (videoQuality: VideoQuality) => {
+    if (!socket) return;
+
+    socket.emit('setVideoQuality', { transportId, quality: videoQuality });
     setVideoQuality(videoQuality);
   };
 
@@ -69,12 +79,12 @@ function LivePlayer({ mediaStream }: { mediaStream: MediaStream | null }) {
         <div className="flex flex-row space-x-6 items-center">
           <Select onValueChange={value => handleVideoQuality(value as VideoQuality)}>
             <SelectTrigger className="w-[80px]">
-              <SelectValue placeholder={videoQuality + 'p'} />
+              <SelectValue placeholder={videoQuality} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="480">480p</SelectItem>
-              <SelectItem value="720">720p</SelectItem>
-              <SelectItem value="1080">1080p</SelectItem>
+              <SelectItem value="480p">480p</SelectItem>
+              <SelectItem value="720p">720p</SelectItem>
+              <SelectItem value="1080p">1080p</SelectItem>
             </SelectContent>
           </Select>
           <button onClick={handleExpand}>

--- a/apps/client/src/pages/Live/LivePlayer.tsx
+++ b/apps/client/src/pages/Live/LivePlayer.tsx
@@ -69,7 +69,7 @@ function LivePlayer({ mediaStream, socket, transportId }: LivePlayerProps) {
         ref={videoRef}
         autoPlay
         muted={isAudioEnabled ? false : true}
-        className=" h-full aspect-video object-cover"
+        className="w-full max-w-[1280px] aspect-video object-contain"
       />
       <div className="absolute bottom-4 left-0 right-0 px-6 text-text-default h-6 flex flex-row justify-between items-center">
         <div className="flex flex-row space-x-6 items-center">

--- a/apps/client/src/pages/Live/LivePlayer.tsx
+++ b/apps/client/src/pages/Live/LivePlayer.tsx
@@ -65,12 +65,7 @@ function LivePlayer({ mediaStream, socket, transportId }: LivePlayerProps) {
 
   return (
     <section className="relative w-full h-full rounded-xl flex justify-center">
-      <video
-        ref={videoRef}
-        autoPlay
-        muted={isAudioEnabled ? false : true}
-        className="w-full max-w-[1280px] aspect-video object-contain"
-      />
+      <video ref={videoRef} autoPlay muted={isAudioEnabled ? false : true} className="w-full max-w-[1280px] h-auto" />
       <div className="absolute bottom-4 left-0 right-0 px-6 text-text-default h-6 flex flex-row justify-between items-center">
         <div className="flex flex-row space-x-6 items-center">
           <button onClick={handlePlayPause}>{isVideoEnabled ? <PauseIcon /> : <PlayIcon />}</button>

--- a/apps/client/src/pages/Live/index.tsx
+++ b/apps/client/src/pages/Live/index.tsx
@@ -68,7 +68,7 @@ export default function Live() {
       ) : (
         <>
           <div className="flex flex-col flex-grow gap-4 h-full ml-8">
-            <LivePlayer mediaStream={mediaStream} />
+            <LivePlayer mediaStream={mediaStream} transportId={transportInfo?.transportId} socket={socket} />
             <LiveCamperInfo liveId={liveId} />
           </div>
           <div className="flex h-full w-80 pr-5">

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -24,7 +24,8 @@
       "@hooks/*": ["./src/hooks/*"],
       "@services/*": ["./src/services/*"],
       "@pages/*": ["./src/pages/*"],
-      "@utils/*": ["./src/utils/*"]
+      "@utils/*": ["./src/utils/*"],
+      "@constants/*": ["./src/constants/*"]
     },
     "outDir": "./dist"
   },


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #31 

## ✨ 구현 기능 명세
- 클라이언트 produce 함수 호출시 encoding 옵션 지정
- 화질 조정 버튼 클릭시 서버에 화질 조정 이벤트 요청
- canvas 해상도 조정 및 화면공유 디스플레이 비율에 맞게 조절

## 🎁 PR Point
- 클라이언트에서 produce 함수 호출 시 인코딩 옵션을 3가지로 하여 producer를 생성합니다.
- 인코딩 옵션은 각각 480p, 720p, 1080p입니다.
- 총 세가지의 인코딩 상태로 스트림을 생성하여 송출하고, consumer는 시청시에 preferedLayer로 세가지 중 하나를 선택해서 시청하게 됩니다.
- canvas의 해상도를 1080p 해상도로 고정했습니다.
- 화면 비율에 맞추어서 화면공유 창 크기가 조절되도록 변경하였습니다.
- video 태그의 높이도 살짝 조정해줬습니다. 1080p 화질의 영상을 볼때 해상도가 높아지다 보니 video 높이가 자동으로 커지는 문제를 해결하기 위해서요.
- 이 pr 머지하지 마시고 현재 프론트엔드 코드가 수정중이라 그거 이후에 충돌해결해서 머지하겠습니다!

## 😭 어려웠던 점
- 화질에 영향을 미치는 친구들을 공부하는게 어려웠어요. 영상은 어려워.
- 720p와 1080p가 구별이 잘 안갑니다. 스트림 자체가 1080p로 설정을 해도 송출이 안되는지 확인해 봐야 할 것 같아요.