### PR TITLE
[Feat] 검색 UI & 로직 구현

### DIFF
--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -22,7 +22,11 @@ function Header() {
   const { isLoggedIn } = useContext(AuthContext);
 
   const handleLogoClick = () => {
-    navigate('/');
+    if (window.location.pathname === '/') {
+      window.location.reload();
+    } else {
+      navigate('/');
+    }
   };
 
   const handleLogInClick = () => {

--- a/apps/client/src/components/Icons/SearchIcon.tsx
+++ b/apps/client/src/components/Icons/SearchIcon.tsx
@@ -1,0 +1,21 @@
+interface IconProps {
+  size?: number;
+  className?: string;
+}
+
+function SearchIcon({ size = 24, className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      className={className}
+    >
+      <path d="M23.707,22.293l-5.969-5.969a10.016,10.016,0,1,0-1.414,1.414l5.969,5.969a1,1,0,0,0,1.414-1.414ZM10,18a8,8,0,1,1,8-8A8.009,8.009,0,0,1,10,18Z" />
+    </svg>
+  );
+}
+
+export default SearchIcon;

--- a/apps/client/src/components/Icons/index.ts
+++ b/apps/client/src/components/Icons/index.ts
@@ -11,6 +11,7 @@ export { default as MicrophoneOffIcon } from './MicrophoneOffIcon';
 export { default as MicrophoneOnIcon } from './MicrophoneOnIcon';
 export { default as ScreenShareIcon } from './ScreenShareIcon';
 export { default as ScreenShareIconOff } from './ScreenShareOffIcon';
+export { default as SearchIcon } from './SearchIcon';
 export { default as GoogleIcon } from './GoogleIcon';
 export { default as PauseIcon } from './PauseIcon';
 export { default as PlayIcon } from './PlayIcon';

--- a/apps/client/src/pages/Home/FieldFilter.tsx
+++ b/apps/client/src/pages/Home/FieldFilter.tsx
@@ -1,16 +1,20 @@
 import { Button } from '@/components/ui/button';
 import { Field } from '@/types/liveTypes';
+import { useState } from 'react';
 
 const fields: Field[] = ['WEB', 'AND', 'IOS'];
 
 interface FieldFilterProps {
-  selectedField: Field;
-  onFieldSelect: (field: Field) => void;
+  onClickFieldButton: (field: Field) => void;
 }
 
-function FieldFilter({ selectedField, onFieldSelect }: FieldFilterProps) {
+function FieldFilter({ onClickFieldButton }: FieldFilterProps) {
+  const [selected, setSelected] = useState<Field>('');
+
   const handleClick = (field: Field) => {
-    onFieldSelect(selectedField === field ? '' : field);
+    const newField = selected === field ? '' : field;
+    onClickFieldButton(newField);
+    setSelected(newField);
   };
 
   return (
@@ -20,7 +24,7 @@ function FieldFilter({ selectedField, onFieldSelect }: FieldFilterProps) {
           key={field}
           onClick={() => handleClick(field)}
           className={`${
-            selectedField === field
+            selected === field
               ? 'bg-surface-brand-default hover:bg-surface-point-alt'
               : 'bg-transparent border border-border-default hover:bg-surface-alt'
           }`}

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -1,13 +1,21 @@
 import FieldFilter from './FieldFilter';
 import LiveCard from './LiveCard';
 import { LivePreviewInfo } from '@/types/homeTypes';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import axiosInstance from '@services/axios';
 import Search from './Search';
 import { Field } from '@/types/liveTypes';
 
 function LiveList() {
   const [liveList, setLiveList] = useState<LivePreviewInfo[]>([]);
+
+  useEffect(() => {
+    axiosInstance.get('v1/broadcasts').then(response => {
+      if (response.data.success) {
+        setLiveList(response.data.data.broadcasts);
+      }
+    });
+  }, []);
 
   const handleFilterField = (field: Field) => {
     axiosInstance.get('/v1/broadcasts', { params: { field: field } }).then(response => {

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -1,25 +1,20 @@
 import FieldFilter from './FieldFilter';
 import LiveCard from './LiveCard';
 import { LivePreviewInfo } from '@/types/homeTypes';
-import { useEffect, useState } from 'react';
-import { Field } from '@/types/liveTypes';
-import axiosInstance from '@/services/axios';
+import { useState } from 'react';
+import axiosInstance from '@services/axios';
 import Search from './Search';
+import { Field } from '@/types/liveTypes';
 
 function LiveList() {
-  const [field, setField] = useState<Field>('');
   const [liveList, setLiveList] = useState<LivePreviewInfo[]>([]);
 
-  useEffect(() => {
+  const handleFilterField = (field: Field) => {
     axiosInstance.get('/v1/broadcasts', { params: { field: field } }).then(response => {
       if (response.data.success) {
         setLiveList(response.data.data.broadcasts);
       }
     });
-  }, [field]);
-
-  const handleSelectField = (selected: Field) => {
-    setField(selected);
   };
 
   const handleSearch = (keyword: string) => {
@@ -33,7 +28,7 @@ function LiveList() {
   return (
     <div className="flex flex-col w-full h-full p-10">
       <div className="h-14 w-full flex justify-between items-center my-5 px-5">
-        <FieldFilter selectedField={field} onFieldSelect={handleSelectField} />
+        <FieldFilter onClickFieldButton={handleFilterField} />
         <Search onSearch={handleSearch} />
       </div>
       <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-x-[clamp(40px,2vw,60px)] gap-y-12 auto-rows-min p-15 w-[95%] max-w-[1920px] align-items-start">

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -22,11 +22,19 @@ function LiveList() {
     setField(selected);
   };
 
+  const handleSearch = (keyword: string) => {
+    axiosInstance.get('v1/broadcasts/search', { params: { keyword: keyword.trim() } }).then(response => {
+      if (response.data.success) {
+        setLiveList(response.data.data);
+      }
+    });
+  };
+
   return (
     <div className="flex flex-col w-full h-full p-10">
       <div className="h-14 w-full flex justify-between items-center my-5 px-5">
         <FieldFilter selectedField={field} onFieldSelect={handleSelectField} />
-        <Search />
+        <Search onSearch={handleSearch} />
       </div>
       <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-x-[clamp(40px,2vw,60px)] gap-y-12 auto-rows-min p-15 w-[95%] max-w-[1920px] align-items-start">
         {liveList ? (

--- a/apps/client/src/pages/Home/Search.tsx
+++ b/apps/client/src/pages/Home/Search.tsx
@@ -1,5 +1,40 @@
-function Search() {
-  return <div className="bg-surface-alt w-52 h-10"></div>;
+import IconButton from '@/components/IconButton';
+import { SearchIcon } from '@/components/Icons';
+import { useForm } from 'react-hook-form';
+
+interface SearchProps {
+  onSearch: (keyword: string) => void;
+}
+
+interface FormInput {
+  keyword: string;
+}
+
+function Search({ onSearch }: SearchProps) {
+  const { register, handleSubmit, reset } = useForm<FormInput>();
+
+  const hanldeSearchSubmit = ({ keyword }: FormInput) => {
+    onSearch(keyword);
+    reset();
+  };
+
+  return (
+    <div className="flex flex-row justify-between items-center w-80 h-10">
+      <form
+        onSubmit={handleSubmit(hanldeSearchSubmit)}
+        className="flex flex-row h-full w-full border border-1 border-border-bold rounded-circle pl-5 pr-2"
+      >
+        <input
+          {...register('keyword', { required: '검색할 방 제목을 입력해주세요' })}
+          className="flex-1 bg-transparent focus-visible:outline-none"
+          placeholder="검색할 방 제목을 입력해주세요"
+        />
+        <IconButton>
+          <SearchIcon />
+        </IconButton>
+      </form>
+    </div>
+  );
 }
 
 export default Search;

--- a/apps/client/src/pages/Home/Search.tsx
+++ b/apps/client/src/pages/Home/Search.tsx
@@ -25,9 +25,9 @@ function Search({ onSearch }: SearchProps) {
         className="flex flex-row h-full w-full border border-1 border-border-bold rounded-circle pl-5 pr-2"
       >
         <input
-          {...register('keyword', { required: '검색할 방 제목을 입력해주세요' })}
+          {...register('keyword', { required: true })}
           className="flex-1 bg-transparent focus-visible:outline-none"
-          placeholder="검색할 방 제목을 입력해주세요"
+          placeholder="검색할 방송 제목을 입력해주세요"
         />
         <IconButton>
           <SearchIcon />

--- a/apps/client/src/pages/Home/Search.tsx
+++ b/apps/client/src/pages/Home/Search.tsx
@@ -11,11 +11,10 @@ interface FormInput {
 }
 
 function Search({ onSearch }: SearchProps) {
-  const { register, handleSubmit, reset } = useForm<FormInput>();
+  const { register, handleSubmit } = useForm<FormInput>();
 
   const hanldeSearchSubmit = ({ keyword }: FormInput) => {
     onSearch(keyword);
-    reset();
   };
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #46

## ✨ 구현 기능 명세

- 검색 UI 구현
- 검색 로직 구현

## 🎁 PR Point

![image](https://github.com/user-attachments/assets/3320eda3-a000-48c2-8a32-6be5c4c221a3)

- (수정 전) 검색 후 검색어 삭제

https://github.com/user-attachments/assets/b46307c9-d547-447d-8a25-71775e9f4d99

- (수정 후) 검색어 남아있음 & 로고 클릭 시 새로고침

https://github.com/user-attachments/assets/2ac1a13a-a592-44bb-b439-3203d86df05c

  - 로고 클릭 시 새로고침
    
    Home에서 로고 클릭 시에만 새로고침되도록 했습니다.
    
    ```typescript
     const handleLogoClick = () => {
      if (window.location.pathname === '/') {
        window.location.reload();
      } else {
        navigate('/');
      }
    };
    ```

### 의견을 듣고 싶은 부분

- 현재 검색한 후에는 검색 키워드를 입력받는 input 창이 리셋되도록 했습니다. 지금처럼 검색 결과가 나올 때는 input창이 초기화되는 것이 괜찮은지, 아니면 검색 결과가 나온 후에도 검색어가 그대로 남아있는 것이 좋다고 생각하는지 궁금합니다.

## 😭 어려웠던 점
