### PR TITLE
[Feat] 내 정보 수정 UI & 로직 구현

### DIFF
--- a/apps/client/src/pages/Live/LiveCamperInfo.tsx
+++ b/apps/client/src/pages/Live/LiveCamperInfo.tsx
@@ -38,7 +38,7 @@ function LiveCamperInfo({ liveId }: { liveId: string }) {
                     variant="outline"
                     className="text-display-medium14 font-medium px-2 py-0.5 text-text-default border-border-default bg-transparent"
                   >
-                    {data.field}
+                    {data.field ? data.field : '???'}
                   </Badge>
                 </div>
                 <span className="text-text-weak text-display-medium12">{data.viewers}명 시청 중</span>

--- a/apps/client/src/pages/Profile/EditUserInfo.tsx
+++ b/apps/client/src/pages/Profile/EditUserInfo.tsx
@@ -1,0 +1,164 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { UserData } from '.';
+import { useForm } from 'react-hook-form';
+import { Field } from '@/types/liveTypes';
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+
+interface EditUserInfoProps {
+  userData: UserData | undefined;
+  toggleEditing: () => void;
+}
+
+interface FormInput {
+  camperId: string | undefined;
+  name: string | undefined;
+  type: Field | undefined;
+  email: string | undefined;
+  github: string | undefined;
+  blog: string | undefined;
+  linkedIn: string | undefined;
+}
+
+function EditUserInfo({ userData, toggleEditing }: EditUserInfoProps) {
+  const [selectedField, setSelectedField] = useState<Field | undefined>(userData?.field);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    defaultValues: {
+      camperId: userData?.camperId,
+      name: userData?.name,
+      type: userData?.field,
+      email: userData?.contacts.email,
+      github: userData?.contacts.github,
+      blog: userData?.contacts.blog,
+      linkedIn: userData?.contacts.linkedIn,
+    },
+  });
+
+  const handleSelectField = (field: Field) => {
+    setSelectedField(selectedField === field ? '' : field);
+  };
+
+  const handlePatchUserInfo = (data: FormInput) => {
+    const formData = {
+      name: data.name,
+      camperId: data.camperId,
+      type: selectedField,
+      contacts: {
+        email: data.email ? data.email : '',
+        github: data.github ? data.github : '',
+        blog: data.blog ? data.blog : '',
+        linkedin: data.linkedIn ? data.linkedIn : '',
+      },
+    };
+    // TODO: 수정 요청
+    alert(formData);
+    toggleEditing();
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-center w-full h-full gap-10">
+      <Avatar className="w-64 h-64">
+        <AvatarImage src={userData?.profileImage} />
+        <AvatarFallback>MY</AvatarFallback>
+      </Avatar>
+      <form onSubmit={handleSubmit(handlePatchUserInfo)} className="flex flex-col w-1/2 gap-5">
+        {(errors.camperId || errors.name) && (
+          <p className="flex justify-end text-text-danger text-display-medium12">
+            {errors.camperId ? errors.camperId.message : errors.name ? errors.name.message : '분야를 선택해주세요'}
+          </p>
+        )}
+        {/* ID */}
+        <div className="flex flex-row justify-center items-center">
+          <label className="w-32 text-text-strong text-display-bold24">ID</label>
+          <input
+            {...register('camperId', {
+              required: 'ID를 입력해주세요',
+            })}
+            className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+          />
+        </div>
+        {/* 이름 */}
+        <div className="flex flex-row justify-center items-center">
+          <label className="w-32 text-text-strong text-display-bold24">이름</label>
+          <input
+            {...register('name', {
+              required: '이름을 입력해주세요',
+            })}
+            className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+          />
+        </div>
+        {/* TODO: 입력 검증 */}
+        {/* email */}
+        <div className="flex flex-row justify-center items-center">
+          <label className="w-32 text-text-strong text-display-bold24">Email</label>
+          <input
+            {...register('email')}
+            className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+          />
+        </div>
+        {/* github */}
+        <div className="flex flex-row justify-center items-center">
+          <label className="w-32 text-text-strong text-display-bold24">Github</label>
+          <input
+            {...register('github')}
+            className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+          />
+        </div>
+        {/* blog */}
+        <div className="flex flex-row justify-center items-center">
+          <label className="w-32 text-text-strong text-display-bold24">Blog</label>
+          <input
+            {...register('blog')}
+            className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+          />
+        </div>
+        {/* linkedIn */}
+        <div className="flex flex-row justify-center items-center">
+          <label className="w-32 text-text-strong text-display-bold24">LinkedIn</label>
+          <input
+            {...register('linkedIn')}
+            className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+          />
+        </div>
+        {/* 분야 */}
+        <div className="flex flex-row justify-start items-center">
+          <label className="w-32 text-text-strong text-display-bold24">분야</label>
+          <div className="flex gap-4">
+            <Button
+              type="button"
+              onClick={() => handleSelectField('WEB')}
+              className={`${selectedField === 'WEB' && 'bg-surface-brand-default hover:bg-surface-brand-alt'}`}
+            >
+              WEB
+            </Button>
+            <Button
+              type="button"
+              onClick={() => handleSelectField('AND')}
+              className={`${selectedField === 'AND' && 'bg-surface-brand-default hover:bg-surface-brand-alt'}`}
+            >
+              AND
+            </Button>
+            <Button
+              type="button"
+              onClick={() => handleSelectField('IOS')}
+              className={`${selectedField === 'IOS' && 'bg-surface-brand-default hover:bg-surface-brand-alt'}`}
+            >
+              IOS
+            </Button>
+          </div>
+        </div>
+        <div className="flex justify-end">
+          <Button type="submit" className="h-10 shrink-0">
+            저장
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default EditUserInfo;

--- a/apps/client/src/pages/Profile/EditUserInfo.tsx
+++ b/apps/client/src/pages/Profile/EditUserInfo.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { Field } from '@/types/liveTypes';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
+import axiosInstance from '@/services/axios';
 
 interface EditUserInfoProps {
   userData: UserData | undefined;
@@ -54,9 +55,15 @@ function EditUserInfo({ userData, toggleEditing }: EditUserInfoProps) {
         linkedin: data.linkedIn ? data.linkedIn : '',
       },
     };
-    // TODO: 수정 요청
-    alert(formData);
-    toggleEditing();
+
+    axiosInstance.patch('/v1/members/info', formData).then(response => {
+      if (response.data.success) {
+        toggleEditing();
+      } else {
+        alert(`내 정보 수정에 실패했습니다: ${response.data.message}`);
+        console.error(`내 정보 수정 실패: ${response.data.status}`);
+      }
+    });
   };
 
   return (

--- a/apps/client/src/pages/Profile/UserInfo.tsx
+++ b/apps/client/src/pages/Profile/UserInfo.tsx
@@ -2,45 +2,18 @@ import ErrorCharacter from '@/components/ErrorCharacter';
 import { BlogIcon, EditIcon, GithubIcon, LinkedInIcon, MailIcon } from '@/components/Icons';
 import LoadingCharacter from '@/components/LoadingCharacter';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import axiosInstance from '@/services/axios';
 import { useEffect, useState } from 'react';
+import { UserData } from '.';
 
-interface UserData {
-  id: number;
-  camperId: string;
-  name: string;
-  field: string;
-  contacts: Contacts;
-  profileImage: string;
+interface UserInfoProps {
+  userData: UserData | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  toggleEditing: () => void;
 }
 
-interface Contacts {
-  email: string;
-  github: string;
-  blog: string;
-  linkedIn: string;
-}
-
-function UserInfo() {
-  const [userData, setUserData] = useState<UserData>();
-  const [isLoading, setIsLoading] = useState(false);
+function UserInfo({ userData, isLoading, error, toggleEditing }: UserInfoProps) {
   const [showLoading, setShowLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    axiosInstance
-      .get('/v1/members/info')
-      .then(response => {
-        if (response.data.success) {
-          setUserData(response.data.data);
-        } else {
-          setError(new Error(response.data.message));
-          console.error('유저 정보 조회 실패:', response.data.status);
-        }
-      })
-      .catch(error => setError(error instanceof Error ? error : new Error(error)))
-      .finally(() => setIsLoading(false));
-  }, [setUserData]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -49,10 +22,6 @@ function UserInfo() {
 
     return () => clearTimeout(timer);
   });
-
-  const handleEditProfile = () => {
-    alert('프로필 수정 구현 예정');
-  };
 
   return (
     <div className="flex flex-row h-1/2 w-full justify-center gap-10">
@@ -82,7 +51,7 @@ function UserInfo() {
                 <div className="flex justify-center items-center bg-surface-brand-default text-text-strong text-display-bold24 h-full w-24 rounded">
                   {userData?.field ? userData.field : '???'}
                 </div>
-                <button onClick={handleEditProfile}>
+                <button onClick={toggleEditing}>
                   <EditIcon size={24} />
                 </button>
               </div>

--- a/apps/client/src/pages/Profile/index.tsx
+++ b/apps/client/src/pages/Profile/index.tsx
@@ -28,8 +28,6 @@ export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
-    setIsEditing(false);
-
     axiosInstance
       .get('/v1/members/info')
       .then(response => {
@@ -42,7 +40,7 @@ export default function Profile() {
       })
       .catch(error => setError(error instanceof Error ? error : new Error(error)))
       .finally(() => setIsLoading(false));
-  }, [setUserData]);
+  }, [isEditing]);
 
   const toggleEditing = () => {
     setIsEditing(prev => !prev);

--- a/apps/client/src/pages/Profile/index.tsx
+++ b/apps/client/src/pages/Profile/index.tsx
@@ -1,11 +1,63 @@
+import { useEffect, useState } from 'react';
 import Attendance from './Attendance';
 import UserInfo from './UserInfo';
+import EditUserInfo from './EditUserInfo';
+import axiosInstance from '@/services/axios';
+import { Field } from '@/types/liveTypes';
+
+export interface UserData {
+  id: number;
+  camperId: string;
+  name: string;
+  field: Field;
+  contacts: Contacts;
+  profileImage: string;
+}
+
+export interface Contacts {
+  email: string;
+  github: string;
+  blog: string;
+  linkedIn: string;
+}
 
 export default function Profile() {
+  const [userData, setUserData] = useState<UserData>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    setIsEditing(false);
+
+    axiosInstance
+      .get('/v1/members/info')
+      .then(response => {
+        if (response.data.success) {
+          setUserData(response.data.data);
+        } else {
+          setError(new Error(response.data.message));
+          console.error('유저 정보 조회 실패:', response.data.status);
+        }
+      })
+      .catch(error => setError(error instanceof Error ? error : new Error(error)))
+      .finally(() => setIsLoading(false));
+  }, [setUserData]);
+
+  const toggleEditing = () => {
+    setIsEditing(prev => !prev);
+  };
+
   return (
     <div className="flex flex-col w-full h-full gap-10">
-      <UserInfo />
-      <Attendance />
+      {isEditing ? (
+        <EditUserInfo toggleEditing={toggleEditing} userData={userData} />
+      ) : (
+        <>
+          <UserInfo toggleEditing={toggleEditing} userData={userData} isLoading={isLoading} error={error} />
+          <Attendance />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/client/src/types/liveTypes.ts
+++ b/apps/client/src/types/liveTypes.ts
@@ -9,7 +9,9 @@ export interface LiveInfo {
   title: string;
   camperId: string;
   viewers: number;
-  field: 'WEB' | 'AND' | 'IOS';
+  field: Field;
   profileImage: string;
   contacts: ContactInfo;
 }
+
+export type Field = 'WEB' | 'AND' | 'IOS' | '';


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #11 

## ✨ 구현 기능 명세

- 개인 정보 수정 UI 구현
- 개인 정보 수정 PATCH 요청 구현

## 🎁 PR Point

![image](https://github.com/user-attachments/assets/627059cf-a1d1-452c-b6d4-99d40b674dc9)

https://github.com/user-attachments/assets/62feb129-3e3a-4cd3-ad78-1606459e750c

### 의견을 듣고 싶은 부분

현재 개인 정보 수정을 할 때 입력이 필수인 것은 "ID"와 "이름"뿐입니다. (WEB, IOS와 같은 분야 같은 경우에는 없을 경우 내 정보 보기 페이지와 방송 시청 페이지에서 분야가 ???으로 나타납니다) 이외에도 필수이어야 한다고 생각하는 필드가 있다면 의견을 말해주세요.

## 😭 어려웠던 점
