### PR TITLE
[Fix] 방송 검색 빈 keyword 입력 시, 전체 방송리스트 반환

### DIFF
--- a/apps/api/src/broadcast/broadcast.service.ts
+++ b/apps/api/src/broadcast/broadcast.service.ts
@@ -71,15 +71,15 @@ export class BroadcastService {
   }
 
   async searchBroadcasts(keyword: string): Promise<Broadcast[]> {
-    if (!keyword) {
-      return [];
+    const queryBuilder = this.broadcastRepository
+      .createQueryBuilder('broadcast')
+      .leftJoinAndSelect('broadcast.member', 'member');
+
+    if (keyword) {
+      queryBuilder.where('broadcast.title LIKE :keyword', { keyword: `%${keyword}%` });
     }
 
-    return this.broadcastRepository
-      .createQueryBuilder('broadcast')
-      .leftJoinAndSelect('broadcast.member', 'member')
-      .where('broadcast.title LIKE :keyword', { keyword: `%${keyword}%` })
-      .getMany();
+    return queryBuilder.getMany();
   }
 
   async createBroadcast({ id, title, thumbnail, memberId }: CreateBroadcastDto): Promise<Broadcast> {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
- #329 

## ✨ 구현 기능 명세
- 빈 문자열 입력 시, 전체 방송 리스트
- keyword 입력 시, 해당 keyword를 포함하는 방송 제목 리스트

## 🎁 PR Point
![image](https://github.com/user-attachments/assets/d559dc60-41f0-409b-a281-332d8e52b5b9)

## 😭 어려웠던 점
