### PR TITLE
[Fix] 최초 로그인 시 개인 정보 페이지가 편집 모드로 전환

### DIFF
--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -72,6 +72,7 @@ function Header() {
   };
 
   useEffect(() => {
+    if (!isLoggedIn) return;
     axiosInstance.get('/v1/members/profile-image').then(response => {
       if (!response.data.success) return;
       setProfileImgUrl(response.data.data.profileImage);
@@ -79,7 +80,7 @@ function Header() {
   }, [isLoggedIn]);
 
   return (
-    <header className="fixed top-0 left-0 w-full px-10 py-3 flex justify-between z-10 bg-surface-default">
+    <header className="fixed top-0 left-0 h-fit w-full px-10 py-3 flex justify-between z-10 bg-surface-default">
       <div className="flex flex-row gap-2 hover:cursor-pointer" onClick={handleLogoClick}>
         <Character size={48} />
         <Logo width={109} height={50} />

--- a/apps/client/src/pages/Home/Banner.tsx
+++ b/apps/client/src/pages/Home/Banner.tsx
@@ -65,6 +65,7 @@ function Banner() {
   };
 
   useEffect(() => {
+    if (!isLoggedIn) return;
     axiosInstance.get('/v1/bookmarks').then(response => {
       if (response.data.success) {
         setBookmarkList(response.data.data.bookmarks);
@@ -73,7 +74,7 @@ function Banner() {
         console.error(`북마크 조회 실패: ${response.data.status}`);
       }
     });
-  }, []);
+  }, [isLoggedIn]);
 
   return (
     <div className="flex w-full h-96 bg-gradient-to-r from-surface-alt to-transparent">

--- a/apps/client/src/pages/Profile/UserInfo.tsx
+++ b/apps/client/src/pages/Profile/UserInfo.tsx
@@ -1,84 +1,59 @@
-import ErrorCharacter from '@/components/ErrorCharacter';
 import { BlogIcon, EditIcon, GithubIcon, LinkedInIcon, MailIcon } from '@/components/Icons';
-import LoadingCharacter from '@/components/LoadingCharacter';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { useEffect, useState } from 'react';
 import { UserData } from '.';
 
 interface UserInfoProps {
   userData: UserData | undefined;
-  isLoading: boolean;
-  error: Error | null;
   toggleEditing: () => void;
 }
 
-function UserInfo({ userData, isLoading, error, toggleEditing }: UserInfoProps) {
-  const [showLoading, setShowLoading] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setShowLoading(true);
-    }, 250);
-
-    return () => clearTimeout(timer);
-  });
-
+function UserInfo({ userData, toggleEditing }: UserInfoProps) {
   return (
     <div className="flex flex-row h-1/2 w-full justify-center gap-10">
-      {showLoading && isLoading ? (
-        <div className="flex justify-center items-center">
-          <LoadingCharacter size={200} />
+      <>
+        <div className="flex flex-col justify-center w-64 h-full gap-5">
+          <Avatar className="w-64 h-64">
+            <AvatarImage src={userData?.profileImage} />
+            <AvatarFallback>MY</AvatarFallback>
+          </Avatar>
+          <div className="text-center font-bold text-text-strong text-4xl">{userData?.name}</div>
         </div>
-      ) : error ? (
-        <div className="flex justify-center items-center">
-          <ErrorCharacter size={200} />
-        </div>
-      ) : (
-        <>
-          <div className="flex flex-col justify-center w-64 h-full gap-5">
-            <Avatar className="w-64 h-64">
-              <AvatarImage src={userData?.profileImage} />
-              <AvatarFallback>MY</AvatarFallback>
-            </Avatar>
-            <div className="text-center font-bold text-text-strong text-4xl">{userData?.name}</div>
-          </div>
-          <div className="flex items-center items w-1/3 h-full">
-            <div className="flex flex-col h-3/5 justify-between">
-              <div className="flex flex-row gap-5 items-center">
-                <span className="font-bold text-text-strong text-4xl">
-                  {userData?.camperId ? userData.camperId : '???'}
-                </span>
-                <div className="flex justify-center items-center bg-surface-brand-default text-text-strong text-display-bold24 h-full w-24 rounded">
-                  {userData?.field ? userData.field : '???'}
-                </div>
-                <button onClick={toggleEditing}>
-                  <EditIcon size={24} />
-                </button>
+        <div className="flex items-center items w-1/3 h-full">
+          <div className="flex flex-col h-3/5 justify-between">
+            <div className="flex flex-row gap-5 items-center">
+              <span className="font-bold text-text-strong text-4xl">
+                {userData?.camperId ? userData.camperId : '???'}
+              </span>
+              <div className="flex justify-center items-center bg-surface-brand-default text-text-strong text-display-bold24 h-full w-24 rounded">
+                {userData?.field ? userData.field : '???'}
               </div>
-              <div className="flex flex-row gap-5 items-center">
-                <MailIcon size={27} className="text-text-strong" />
-                <span className="text-text-strong text-display-bold24 w-24 h-full">email</span>
-                <span className="text-text-strong text-display-medium16">{userData?.contacts.email}</span>
-              </div>
-              <div className="flex flex-row gap-5 items-center">
-                <GithubIcon size={27} className="text-text-strong" />
-                <span className="text-text-strong text-display-bold24 w-24 h-full">Github</span>
-                <span className="text-text-strong text-display-medium16">{userData?.contacts.github}</span>
-              </div>
-              <div className="flex flex-row gap-5 items-center">
-                <BlogIcon size={27} className="text-text-strong" />
-                <span className="text-text-strong text-display-bold24 w-24 h-full">Blog</span>
-                <span className="text-text-strong text-display-medium16">{userData?.contacts.blog}</span>
-              </div>
-              <div className="flex flex-row gap-5 items-center">
-                <LinkedInIcon size={27} className="text-text-strong" />
-                <span className="text-text-strong text-display-bold24 w-24 h-full">LinkedIn</span>
-                <span className="text-text-strong text-display-medium16">{userData?.contacts.linkedIn}</span>
-              </div>
+              <button onClick={toggleEditing}>
+                <EditIcon size={24} />
+              </button>
+            </div>
+            <div className="flex flex-row gap-5 items-center">
+              <MailIcon size={27} className="text-text-strong" />
+              <span className="text-text-strong text-display-bold24 w-24 h-full">email</span>
+              <span className="text-text-strong text-display-medium16">{userData?.contacts.email}</span>
+            </div>
+            <div className="flex flex-row gap-5 items-center">
+              <GithubIcon size={27} className="text-text-strong" />
+              <span className="text-text-strong text-display-bold24 w-24 h-full">Github</span>
+              <span className="text-text-strong text-display-medium16">{userData?.contacts.github}</span>
+            </div>
+            <div className="flex flex-row gap-5 items-center">
+              <BlogIcon size={27} className="text-text-strong" />
+              <span className="text-text-strong text-display-bold24 w-24 h-full">Blog</span>
+              <span className="text-text-strong text-display-medium16">{userData?.contacts.blog}</span>
+            </div>
+            <div className="flex flex-row gap-5 items-center">
+              <LinkedInIcon size={27} className="text-text-strong" />
+              <span className="text-text-strong text-display-bold24 w-24 h-full">LinkedIn</span>
+              <span className="text-text-strong text-display-medium16">{userData?.contacts.linkedIn}</span>
             </div>
           </div>
-        </>
-      )}
+        </div>
+      </>
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #343 

## ✨ 구현 기능 명세

- 최초 로그인 시 개인 정보 페이지가 편집 모드로 전환
- 로그인되지 않은 상태일 때 헤더와 배너에서 불필요한 API 요청 보내지 않도록 처리

## 🎁 PR Point

## 😭 어려웠던 점
