### PR TITLE
[Feat] 로그인 여부에 따른 접근 제한 처리 및 기타 리팩토링

### DIFF
--- a/apps/client/src/ProtectedRoute.tsx
+++ b/apps/client/src/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { AuthContext } from '@contexts/AuthContext';
+import { Navigate, Outlet } from 'react-router-dom';
+
+function ProtectedRoute() {
+  const { isLoggedIn } = useContext(AuthContext);
+  const accessToken = localStorage.getItem('accessToken');
+
+  return isLoggedIn || accessToken ? <Outlet /> : <Navigate to="/" replace />;
+}
+
+export default ProtectedRoute;

--- a/apps/client/src/Router.tsx
+++ b/apps/client/src/Router.tsx
@@ -6,6 +6,7 @@ import Live from '@pages/Live';
 import Broadcast from '@pages/Broadcast';
 import Auth from '@pages/Auth';
 import Record from '@pages/Record';
+import ProtectedRoute from './protectedRoute';
 
 const routerOptions = {
   future: {
@@ -29,10 +30,6 @@ const router = createBrowserRouter(
           element: <Home />,
         },
         {
-          path: 'profile',
-          element: <Profile />,
-        },
-        {
           path: 'live/:liveId',
           element: <Live />,
         },
@@ -41,14 +38,31 @@ const router = createBrowserRouter(
           element: <Auth />,
         },
         {
-          path: 'record/:attendanceId',
-          element: <Record />,
+          path: '',
+          element: <ProtectedRoute />,
+          children: [
+            {
+              path: 'profile',
+              element: <Profile />,
+            },
+
+            {
+              path: 'record/:attendanceId',
+              element: <Record />,
+            },
+          ],
         },
       ],
     },
     {
       path: 'broadcast',
-      element: <Broadcast />,
+      element: <ProtectedRoute />,
+      children: [
+        {
+          path: '',
+          element: <Broadcast />,
+        },
+      ],
     },
   ],
   routerOptions,

--- a/apps/client/src/components/ChatContainer/index.tsx
+++ b/apps/client/src/components/ChatContainer/index.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useContext } from 'react';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@components/ui/card';
 import { Input } from '@components/ui/input';
 import { SmileIcon } from '@/components/Icons';
 import { useSocket } from '@hooks/useSocket';
 import ErrorCharacter from '@components/ErrorCharacter';
+import { AuthContext } from '@/contexts/AuthContext';
 
 interface Chat {
   camperId: string;
@@ -14,6 +15,7 @@ interface Chat {
 const chatServerUrl = import.meta.env.VITE_CHAT_SERVER_URL;
 
 const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boolean }) => {
+  const { isLoggedIn } = useContext(AuthContext);
   // 채팅 방 입장
   const [isJoinedRoom, setIsJoinedRoom] = useState(false);
   // 채팅 전송
@@ -72,6 +74,10 @@ const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boo
     setChattings(prev => [...prev, { camperId, name, message }]);
   };
 
+  const handleClickEmoticon = () => {
+    alert('구현 예정');
+  };
+
   useEffect(() => {
     if (!isConnected || !socket || !roomId || isJoinedRoom) return;
     console.log(`roomId: ${JSON.stringify(roomId)}`);
@@ -95,7 +101,7 @@ const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boo
         <CardTitle className="font-bold text-text-strong">Chat</CardTitle>
       </CardHeader>
       {socketError ? (
-        <div className="flex justify-center items-center">
+        <div className="flex justify-center items-center w-full h-full">
           <ErrorCharacter size={200} message={socketError.message} />
         </div>
       ) : (
@@ -114,15 +120,20 @@ const ChatContainer = ({ roomId, isProducer }: { roomId: string; isProducer: boo
             <div className="flex items-center w-full rounded-xl bg-surface-alt">
               <Input
                 type="text"
-                placeholder="채팅을 입력해주세요"
+                placeholder={isLoggedIn ? '채팅을 입력해주세요' : '로그인 후 이용해주세요'}
                 value={inputValue}
                 onChange={handleInputChange}
                 onCompositionStart={() => setIsComposing(true)}
                 onCompositionEnd={() => setIsComposing(false)}
                 onKeyDown={hanldeKeyDownEnter}
                 className="flex-1 text-text-default border-none focus-visible:outline-none focus-visible:ring-0"
+                disabled={!isLoggedIn}
               />
-              <button className="ml-2 p-2 rounded-full text-text-default">
+              <button
+                onClick={handleClickEmoticon}
+                className="ml-2 p-2 rounded-full text-text-default"
+                disabled={!isLoggedIn}
+              >
                 <SmileIcon />
               </button>
             </div>

--- a/apps/client/src/pages/Auth/index.tsx
+++ b/apps/client/src/pages/Auth/index.tsx
@@ -31,7 +31,7 @@ function Auth() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       {error ? (
-        <ErrorCharacter size={400} message={error.message} />
+        <ErrorCharacter size={400} message="로그인 처리 중 문제가 발생했습니다." />
       ) : (
         <div>
           <h2 className="text-display-bold24 text-text-strong">로그인 처리 중입니다.</h2>

--- a/apps/client/src/pages/Broadcast/index.tsx
+++ b/apps/client/src/pages/Broadcast/index.tsx
@@ -115,18 +115,7 @@ function Broadcast() {
   if (socketError || roomError || transportError || screenShareError) {
     return (
       <div className="flex h-full justify-center items-center">
-        <ErrorCharacter
-          size={300}
-          message={`방송 연결 중 에러가 발생했습니다: ${
-            socketError
-              ? socketError.message
-              : roomError
-              ? roomError.message
-              : transportError
-              ? transportError.message
-              : screenShareError?.message
-          }`}
-        />
+        <ErrorCharacter size={300} message="방송 연결 중 에러가 발생했습니다" />
       </div>
     );
   }

--- a/apps/client/src/pages/Broadcast/index.tsx
+++ b/apps/client/src/pages/Broadcast/index.tsx
@@ -113,6 +113,7 @@ function Broadcast() {
   };
 
   if (socketError || roomError || transportError || screenShareError) {
+    mediaStream?.getTracks().forEach((track: MediaStreamTrack) => track.stop());
     return (
       <div className="flex h-full justify-center items-center">
         <ErrorCharacter size={300} message="방송 연결 중 에러가 발생했습니다" />

--- a/apps/client/src/pages/Home/Banner.tsx
+++ b/apps/client/src/pages/Home/Banner.tsx
@@ -1,80 +1,7 @@
-import { CloseIcon } from '@/components/Icons';
-import Modal from '@/components/Modal';
-import { Button } from '@/components/ui/button';
-import { AuthContext } from '@/contexts/AuthContext';
-import { useToast } from '@hooks/useToast';
-import axiosInstance from '@/services/axios';
-import { useContext, useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { useForm } from 'react-hook-form';
 import MoveCharacter from '@/components/Icons/MoveCharacter';
-
-interface BookmarkData {
-  bookmarkId: number;
-  name: string;
-  url: string;
-}
+import Bookmark from './Bookmark';
 
 function Banner() {
-  const { isLoggedIn } = useContext(AuthContext);
-  const [bookmarkList, setBookmarkList] = useState<BookmarkData[]>([]);
-  const [showModal, setShowModal] = useState(false);
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    reset,
-  } = useForm<BookmarkData>();
-  const { toast } = useToast();
-
-  const handleClickBookmarkButton = (url: string) => {
-    window.open(url);
-  };
-
-  const handleAddBookmark = (newBookmark: BookmarkData) => {
-    axiosInstance
-      .post('/v1/bookmarks', newBookmark)
-      .then(response => {
-        if (response.data.success) {
-          const addedBookmark = { ...newBookmark, bookmarkId: response.data.data.bookmarkId };
-          const newBookmarkList = [...bookmarkList, addedBookmark];
-          setBookmarkList(newBookmarkList);
-        } else {
-          toast({ variant: 'destructive', title: '북마크 생성 실패', description: response.data.message });
-          console.error(`북마크 생성 실패: ${response.data.status}`);
-        }
-      })
-      .finally(() => {
-        reset();
-        setShowModal(false);
-      });
-  };
-
-  const handleDeleteBookmark = (e: React.MouseEvent, bookmarkId: number) => {
-    e.stopPropagation();
-
-    axiosInstance.delete(`/v1/bookmarks/${bookmarkId}`).then(response => {
-      if (response.data.success) {
-        const newBookmarkList = bookmarkList.filter((data, _) => data.bookmarkId !== bookmarkId);
-        setBookmarkList(newBookmarkList);
-      } else {
-        toast({ variant: 'destructive', title: '북마크 삭제 실패', description: response.data.message });
-        console.error(`북마크 삭제 실패: ${response.data.status}`);
-      }
-    });
-  };
-
-  useEffect(() => {
-    axiosInstance.get('/v1/bookmarks').then(response => {
-      if (response.data.success) {
-        setBookmarkList(response.data.data.bookmarks);
-      } else {
-        toast({ variant: 'destructive', title: '북마크 조회 실패', description: response.data.message });
-        console.error(`북마크 조회 실패: ${response.data.status}`);
-      }
-    });
-  }, []);
-
   return (
     <div className="flex w-full h-96 bg-gradient-to-r from-surface-alt to-transparent">
       <div className="flex flex-row justify-between w-full h-96 p-5">
@@ -87,76 +14,8 @@ function Banner() {
             </p>
           </div>
         </div>
-        {isLoggedIn && (
-          <div className="flex flex-col h-full gap-3 p-3">
-            {bookmarkList &&
-              bookmarkList.map(data => (
-                <Button
-                  key={data.bookmarkId}
-                  onClick={() => handleClickBookmarkButton(data.url)}
-                  className="h-14 w-52 bg-surface-alt hover:bg-surface-alt-light relative flex items-center justify-between"
-                >
-                  <span className="truncate flex-1">{data.name}</span>
-                  <div
-                    onClick={e => handleDeleteBookmark(e, data.bookmarkId)}
-                    className="flex items-center p-1 hover:text-text-strong hover:cursor-pointer"
-                  >
-                    <CloseIcon size={36} />
-                  </div>
-                </Button>
-              ))}
-
-            {bookmarkList.length < 5 && (
-              <Button
-                onClick={() => setShowModal(true)}
-                className="h-14 w-52 bg-surface-alt hover:bg-surface-alt-light"
-              >
-                +
-              </Button>
-            )}
-          </div>
-        )}
+        <Bookmark />
       </div>
-      {showModal &&
-        createPortal(
-          <Modal setShowModal={setShowModal} modalClassName="h-fit w-1/3">
-            <div className="flex w-full h-full p-4">
-              <form onSubmit={handleSubmit(handleAddBookmark)} className="flex flex-col gap-2 w-full">
-                <div className="flex flex-col gap-3 w-full">
-                  <div className="flex flex-col w-full">
-                    <label>사이트명</label>
-                    <input
-                      {...register('name', {
-                        required: '북마크 이름을 입력해주세요',
-                      })}
-                      className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
-                    />
-                  </div>
-                  <div className="flex flex-col w-full">
-                    <label>URL</label>
-                    <input
-                      {...register('url', {
-                        required: '저장할 사이트 URL을 입력해주세요',
-                      })}
-                      className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
-                    />
-                  </div>
-                  {(errors.name || errors.url) && (
-                    <p className="absolute top-11 text-text-danger font-medium text-display-medium12">
-                      {errors.name ? errors.name.message : errors.url?.message}
-                    </p>
-                  )}
-                </div>
-                <div className="flex justify-end">
-                  <Button type="submit" className="h-10 shrink-0">
-                    저장
-                  </Button>
-                </div>
-              </form>
-            </div>
-          </Modal>,
-          document.body,
-        )}
     </div>
   );
 }

--- a/apps/client/src/pages/Home/Bookmark.tsx
+++ b/apps/client/src/pages/Home/Bookmark.tsx
@@ -1,0 +1,151 @@
+import Modal from '@components/Modal';
+import { Button } from '@components/ui/button';
+import { createPortal } from 'react-dom';
+import { useForm } from 'react-hook-form';
+import { useToast } from '@hooks/useToast';
+import { AuthContext } from '@contexts/AuthContext';
+import axiosInstance from '@services/axios';
+import { useContext, useEffect, useState } from 'react';
+import { CloseIcon } from '@components/Icons';
+
+interface BookmarkData {
+  bookmarkId: number;
+  name: string;
+  url: string;
+}
+
+function Bookmark() {
+  const { isLoggedIn } = useContext(AuthContext);
+  const [bookmarkList, setBookmarkList] = useState<BookmarkData[]>([]);
+  const [showModal, setShowModal] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<BookmarkData>();
+  const { toast } = useToast();
+
+  const handleClickBookmarkButton = (url: string) => {
+    window.open(url);
+  };
+
+  const handleAddBookmark = (newBookmark: BookmarkData) => {
+    if (!isLoggedIn) return;
+    axiosInstance
+      .post('/v1/bookmarks', newBookmark)
+      .then(response => {
+        if (response.data.success) {
+          const addedBookmark = { ...newBookmark, bookmarkId: response.data.data.bookmarkId };
+          const newBookmarkList = [...bookmarkList, addedBookmark];
+          setBookmarkList(newBookmarkList);
+        } else {
+          toast({ variant: 'destructive', title: '북마크 생성 실패', description: response.data.message });
+          console.error(`북마크 생성 실패: ${response.data.status}`);
+        }
+      })
+      .finally(() => {
+        reset();
+        setShowModal(false);
+      });
+  };
+
+  const handleDeleteBookmark = (e: React.MouseEvent, bookmarkId: number) => {
+    e.stopPropagation();
+
+    if (!isLoggedIn) return;
+    axiosInstance.delete(`/v1/bookmarks/${bookmarkId}`).then(response => {
+      if (response.data.success) {
+        const newBookmarkList = bookmarkList.filter((data, _) => data.bookmarkId !== bookmarkId);
+        setBookmarkList(newBookmarkList);
+      } else {
+        toast({ variant: 'destructive', title: '북마크 삭제 실패', description: response.data.message });
+        console.error(`북마크 삭제 실패: ${response.data.status}`);
+      }
+    });
+  };
+
+  useEffect(() => {
+    axiosInstance.get('/v1/bookmarks').then(response => {
+      if (response.data.success) {
+        setBookmarkList(response.data.data.bookmarks);
+      } else {
+        toast({ variant: 'destructive', title: '북마크 조회 실패', description: response.data.message });
+        console.error(`북마크 조회 실패: ${response.data.status}`);
+      }
+    });
+  }, []);
+
+  return (
+    <>
+      {isLoggedIn && (
+        <div className="flex flex-col h-full gap-3 p-3">
+          {bookmarkList &&
+            bookmarkList.map(data => (
+              <Button
+                key={data.bookmarkId}
+                onClick={() => handleClickBookmarkButton(data.url)}
+                className="h-14 w-52 bg-surface-alt hover:bg-surface-alt-light relative flex items-center justify-between"
+              >
+                <span className="truncate flex-1">{data.name}</span>
+                <div
+                  onClick={e => handleDeleteBookmark(e, data.bookmarkId)}
+                  className="flex items-center p-1 hover:text-text-strong hover:cursor-pointer"
+                >
+                  <CloseIcon size={36} />
+                </div>
+              </Button>
+            ))}
+
+          {bookmarkList.length < 5 && (
+            <Button onClick={() => setShowModal(true)} className="h-14 w-52 bg-surface-alt hover:bg-surface-alt-light">
+              +
+            </Button>
+          )}
+        </div>
+      )}
+      {showModal &&
+        createPortal(
+          <Modal setShowModal={setShowModal} modalClassName="h-fit w-1/3">
+            <div className="flex w-full h-full p-4">
+              <form onSubmit={handleSubmit(handleAddBookmark)} className="flex flex-col gap-2 w-full">
+                <div className="flex flex-col gap-3 w-full">
+                  <div className="flex flex-col w-full">
+                    <label>사이트명</label>
+                    <input
+                      {...register('name', {
+                        required: '북마크 이름을 입력해주세요',
+                      })}
+                      className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+                    />
+                  </div>
+                  <div className="flex flex-col w-full">
+                    <label>URL</label>
+                    <input
+                      {...register('url', {
+                        required: '저장할 사이트 URL을 입력해주세요',
+                      })}
+                      className="w-full h-10 bg-transparent border border-default rounded-md focus:border-bold px-3"
+                    />
+                  </div>
+                  {(errors.name || errors.url) && (
+                    <p className="absolute top-11 text-text-danger font-medium text-display-medium12">
+                      {errors.name ? errors.name.message : errors.url?.message}
+                    </p>
+                  )}
+                </div>
+                <div className="flex justify-end">
+                  <Button type="submit" className="h-10 shrink-0">
+                    저장
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </Modal>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+export default Bookmark;

--- a/apps/client/src/pages/Live/LivePlayer.tsx
+++ b/apps/client/src/pages/Live/LivePlayer.tsx
@@ -2,20 +2,30 @@ import { useEffect, useRef, useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@components/ui/select';
 import { PlayIcon, PauseIcon, VolumeOffIcon, VolumeOnIcon, ExpandIcon } from '@/components/Icons';
 import { Socket } from 'socket.io-client';
+import ErrorCharacter from '@/components/ErrorCharacter';
+
+interface Errors {
+  socketError: Error | null;
+  transportError: Error | null;
+  consumerError: Error | null;
+}
 
 interface LivePlayerProps {
   mediaStream: MediaStream | null;
   socket: Socket | null;
   transportId: string | undefined;
+  errors: Errors;
 }
 
 type VideoQuality = '480p' | '720p' | '1080p';
 
-function LivePlayer({ mediaStream, socket, transportId }: LivePlayerProps) {
+function LivePlayer({ mediaStream, socket, transportId, errors }: LivePlayerProps) {
   const [isVideoEnabled, setIsVideoEnabled] = useState(true);
   const [isAudioEnabled, setIsAudioEnabled] = useState(false);
   const [videoQuality, setVideoQuality] = useState('720p');
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  const { socketError, transportError, consumerError } = errors;
 
   useEffect(() => {
     const videoElement = videoRef.current;
@@ -64,30 +74,43 @@ function LivePlayer({ mediaStream, socket, transportId }: LivePlayerProps) {
   };
 
   return (
-    <section className="relative w-full h-full rounded-xl flex justify-center">
-      <video ref={videoRef} autoPlay muted={isAudioEnabled ? false : true} className="w-full max-w-[1280px] h-auto" />
-      <div className="absolute bottom-4 left-0 right-0 px-6 text-text-default h-6 flex flex-row justify-between items-center">
-        <div className="flex flex-row space-x-6 items-center">
-          <button onClick={handlePlayPause}>{isVideoEnabled ? <PauseIcon /> : <PlayIcon />}</button>
-          <button onClick={handleMute}>{isAudioEnabled ? <VolumeOnIcon /> : <VolumeOffIcon />}</button>
+    <>
+      {socketError || transportError || consumerError ? (
+        <div className="flex w-full h-full justify-center items-center">
+          <ErrorCharacter size={400} message={`방송 연결 중 에러가 발생했습니다`} />
         </div>
-        <div className="flex flex-row space-x-6 items-center">
-          <Select onValueChange={value => handleVideoQuality(value as VideoQuality)}>
-            <SelectTrigger className="w-[80px]">
-              <SelectValue placeholder={videoQuality} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="480p">480p</SelectItem>
-              <SelectItem value="720p">720p</SelectItem>
-              <SelectItem value="1080p">1080p</SelectItem>
-            </SelectContent>
-          </Select>
-          <button onClick={handleExpand}>
-            <ExpandIcon />
-          </button>
-        </div>
-      </div>
-    </section>
+      ) : (
+        <section className="relative w-full h-full rounded-xl flex justify-center">
+          <video
+            ref={videoRef}
+            autoPlay
+            muted={isAudioEnabled ? false : true}
+            className="w-full max-w-[1280px] h-auto"
+          />
+          <div className="absolute bottom-4 left-0 right-0 px-6 text-text-default h-6 flex flex-row justify-between items-center">
+            <div className="flex flex-row space-x-6 items-center">
+              <button onClick={handlePlayPause}>{isVideoEnabled ? <PauseIcon /> : <PlayIcon />}</button>
+              <button onClick={handleMute}>{isAudioEnabled ? <VolumeOnIcon /> : <VolumeOffIcon />}</button>
+            </div>
+            <div className="flex flex-row space-x-6 items-center">
+              <Select onValueChange={value => handleVideoQuality(value as VideoQuality)}>
+                <SelectTrigger className="w-[80px]">
+                  <SelectValue placeholder={videoQuality} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="480p">480p</SelectItem>
+                  <SelectItem value="720p">720p</SelectItem>
+                  <SelectItem value="1080p">1080p</SelectItem>
+                </SelectContent>
+              </Select>
+              <button onClick={handleExpand}>
+                <ExpandIcon />
+              </button>
+            </div>
+          </div>
+        </section>
+      )}
+    </>
   );
 }
 

--- a/apps/client/src/pages/Live/index.tsx
+++ b/apps/client/src/pages/Live/index.tsx
@@ -21,7 +21,7 @@ export default function Live() {
   const {
     transport,
     mediastream: mediaStream,
-    error: _error,
+    error: consumerError,
   } = useConsumer({
     socket,
     device,
@@ -56,19 +56,17 @@ export default function Live() {
 
   return (
     <div className="h-full bottom-0 left-0 right-0 overflow-auto flex flex-row w-full gap-10">
-      {socketError || transportError ? (
-        <div className="flex w-full h-full justify-center items-center">
-          <ErrorCharacter
-            size={400}
-            message={`방송 연결 중 에러가 발생했습니다: ${socketError ? socketError.message : transportError?.message}`}
-          />
-        </div>
-      ) : !liveId ? (
+      {!liveId ? (
         <ErrorCharacter size={400} message="방 정보가 없습니다." />
       ) : (
         <>
           <div className="flex flex-col flex-grow gap-4 h-full ml-8">
-            <LivePlayer mediaStream={mediaStream} transportId={transportInfo?.transportId} socket={socket} />
+            <LivePlayer
+              mediaStream={mediaStream}
+              transportId={transportInfo?.transportId}
+              socket={socket}
+              errors={{ socketError, transportError, consumerError }}
+            />
             <LiveCamperInfo liveId={liveId} />
           </div>
           <div className="flex h-full w-80 pr-5">

--- a/apps/client/src/pages/Profile/Attendance.tsx
+++ b/apps/client/src/pages/Profile/Attendance.tsx
@@ -66,7 +66,7 @@ function Attendance() {
           </div>
         ) : error ? (
           <div className="flex justify-center items-center h-full">
-            <ErrorCharacter size={200} message={error.message} />
+            <ErrorCharacter size={200} message="출석부 조회에 실패했습니다" />
           </div>
         ) : (
           <div className="overflow-y-auto text-text-default text-display-medium16">

--- a/apps/client/src/pages/Profile/UserInfo.tsx
+++ b/apps/client/src/pages/Profile/UserInfo.tsx
@@ -31,7 +31,7 @@ function UserInfo({ userData, isLoading, error, toggleEditing }: UserInfoProps) 
         </div>
       ) : error ? (
         <div className="flex justify-center items-center">
-          <ErrorCharacter size={200} />
+          <ErrorCharacter size={200} message="유저 정보 조회에 실패했습니다" />
         </div>
       ) : (
         <>

--- a/apps/client/src/pages/Record/RecordList.tsx
+++ b/apps/client/src/pages/Record/RecordList.tsx
@@ -15,20 +15,17 @@ function RecordList(props: RecordListProps) {
   const [error, setError] = useState<string>('');
 
   useEffect(() => {
-    axiosInstance
-      .get(`/v1/records/${attendanceId}`)
-      .then(response => {
-        if (response.data.success) setRecordList(response.data.data.records);
-        else setError(response.data.message);
-      })
-      .catch(reason => setError(reason));
+    axiosInstance.get(`/v1/records/${attendanceId}`).then(response => {
+      if (response.data.success) setRecordList(response.data.data.records);
+      else setError(response.data.message);
+    });
   }, []);
 
   return (
     <div className="flex h-full w-full border border-border-default rounded p-5 overflow-hidden">
       {error ? (
         <div>
-          <ErrorCharacter size={100} message={error} />
+          <ErrorCharacter size={100} message="녹화 영상 목록 조회에 실패했습니다" />
         </div>
       ) : (
         <div className="h-full w-full overflow-y-auto">

--- a/apps/client/src/pages/Record/index.tsx
+++ b/apps/client/src/pages/Record/index.tsx
@@ -14,7 +14,7 @@ function Record() {
   const [nowPlaying, setIsNowPlaying] = useState<RecordData>({ recordId: 0, title: '', video: '', date: '' });
 
   return (
-    <div className="h-[calc(100vh-74px)] flex flex-row w-full gap-10">
+    <div className="flex flex-row w-full h-full gap-10">
       <>
         <div className="flex flex-col flex-grow gap-4 h-full ml-8">
           <RecordPlayer video={nowPlaying.video} />


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #345 

## ✨ 구현 기능 명세

- 로그인 여부에 따른 접근 제한
- 로그인 시 채팅을 입력할 수 없도록 처리
- 에러 처리 수정
- 북마크 컴포넌트를 배너에서부터 분리
- 방송 송출 연결 중 에러 발생 시 미디어 스트림 정리

## 🎁 PR Point

### 로그인 여부에 따른 접근 제한

로그인 여부에 따라 접근이 제한되어야 하는 페이지를 관리하기 위해 `ProtectedRoute` 컴포넌트를 만들어서 관리하도록 했다.

```typescript
import { useContext } from 'react';
import { AuthContext } from '@contexts/AuthContext';
import { Navigate, Outlet } from 'react-router-dom';

function ProtectedRoute() {
  const { isLoggedIn } = useContext(AuthContext);
  const accessToken = localStorage.getItem('accessToken');

  return isLoggedIn || accessToken ? <Outlet /> : <Navigate to="/" replace />;
}

export default ProtectedRoute;
```

그리고 Router.tsx에서 다음과 같이 `ProtectedRoute`로 감싸준다.

```typescript
import { createBrowserRouter } from 'react-router-dom';
// 페이지 import ...

const routerOptions = {
  // ...
};

const router = createBrowserRouter(
  [
    {
      path: '/',
      element: <App />,
      children: [
        {
          path: '',
          element: <Home />,
        },
        {
          path: 'live/:liveId',
          element: <Live />,
        },
        {
          path: 'auth',
          element: <Auth />,
        },
        {
          path: '',
          element: <ProtectedRoute />,
          children: [
            {
              path: 'profile',
              element: <Profile />,
            },

            {
              path: 'record/:attendanceId',
              element: <Record />,
            },
          ],
        },
      ],
    },
    {
      path: 'broadcast',
      element: <ProtectedRoute />,
      children: [
        {
          path: '',
          element: <Broadcast />,
        },
      ],
    },
  ],
  routerOptions,
);

export default router;
```

### 로그인 시 채팅을 입력할 수 없도록 처리

ChatContainer에서 로그인되지 않은 상태일 때, 채팅 입력창을 `disabled`하여 입력할 수 없게 처리했다.

### 에러 처리 수정

- 전체 페이지가 아닌 각 컴포넌트마다 에러를 확인하고 에러 컴포넌트를 띄우도록 수정했다.
- 에러 컴포넌트에 나타나는 메시지는 서버에서 응답으로 넘겨준 에러메시지가 나왔었는데, 이를 없애고 프론트엔드에서 정한 에러메시지가 나오도록 수정했다.

### 방송 송출 연결 중 에러 발생 시 미디어 스트림 정리

Broadcast에서 방송 연결 중에 에러가 발생해도 화상 캠, 마이크와 같은 미디어 스트림이 정리되지 않고 있었다. 그래서 에러 발생 시 아래의 코드를 실행하여 미디어 스트림을 정리하도록 했다.

```typescript
mediaStream?.getTracks().forEach((track: MediaStreamTrack) => track.stop());
```

## 😭 어려웠던 점
