### PR TITLE
[Feat] 방송 목록 무한 스크롤

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -8,7 +8,7 @@ function App() {
   return (
     <AuthProvider>
       <Header />
-      <main className="h-full">
+      <main>
         <Outlet />
       </main>
       <Toaster />

--- a/apps/client/src/components/Footer/index.tsx
+++ b/apps/client/src/components/Footer/index.tsx
@@ -1,6 +1,6 @@
 function Footer() {
   return (
-    <footer className="flex w-full h-32 justify-center items-center">
+    <footer className="relative w-full h-32 translate-y-0 flex justify-center items-center">
       <div className="flex w-2/5 justify-around text-text-weak underline">
         <a href="https://github.com/boostcampwm-2024/web20-camon">Github</a>
         <a href="https://github.com/boostcampwm-2024/web20-camon/wiki">Wiki</a>

--- a/apps/client/src/components/Footer/index.tsx
+++ b/apps/client/src/components/Footer/index.tsx
@@ -1,0 +1,12 @@
+function Footer() {
+  return (
+    <footer className="flex w-full h-full justify-center items-center">
+      <div className="flex w-2/5 justify-around text-text-weak underline">
+        <a href="https://github.com/boostcampwm-2024/web20-camon">Github</a>
+        <a href="https://github.com/boostcampwm-2024/web20-camon/wiki">Wiki</a>
+        <a href="https://www.notion.so/Cam-on-1290201238ac808ebb56d75e07685ae4">노션</a>
+      </div>
+    </footer>
+  );
+}
+export default Footer;

--- a/apps/client/src/components/Footer/index.tsx
+++ b/apps/client/src/components/Footer/index.tsx
@@ -1,6 +1,6 @@
 function Footer() {
   return (
-    <footer className="flex w-full h-full justify-center items-center">
+    <footer className="flex w-full h-32 justify-center items-center">
       <div className="flex w-2/5 justify-around text-text-weak underline">
         <a href="https://github.com/boostcampwm-2024/web20-camon">Github</a>
         <a href="https://github.com/boostcampwm-2024/web20-camon/wiki">Wiki</a>

--- a/apps/client/src/hooks/useIntersect.ts
+++ b/apps/client/src/hooks/useIntersect.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type IntersectHandler = (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void;
+
+interface UseIntersectProps {
+  onIntersect: IntersectHandler;
+  options?: IntersectionObserverInit;
+}
+
+export const useIntersect = ({ onIntersect, options }: UseIntersectProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect],
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, options, callback]);
+
+  return ref;
+};

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,11 +1,6 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import { RouterProvider } from 'react-router-dom';
 import router from './Router';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <RouterProvider router={router} />
-  </StrictMode>,
-);
+createRoot(document.getElementById('root')!).render(<RouterProvider router={router} />);

--- a/apps/client/src/pages/Home/FieldFilter.tsx
+++ b/apps/client/src/pages/Home/FieldFilter.tsx
@@ -5,16 +5,16 @@ import { useState } from 'react';
 const fields: Field[] = ['WEB', 'AND', 'IOS'];
 
 interface FieldFilterProps {
-  onClickFieldButton: (field: Field) => void;
+  onClickFilterButton: (field: Field) => void;
 }
 
-function FieldFilter({ onClickFieldButton }: FieldFilterProps) {
+function FieldFilter({ onClickFilterButton }: FieldFilterProps) {
   const [selected, setSelected] = useState<Field>('');
 
   const handleClick = (field: Field) => {
     const newField = selected === field ? '' : field;
-    onClickFieldButton(newField);
     setSelected(newField);
+    onClickFilterButton(newField);
   };
 
   return (

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -5,28 +5,52 @@ import { useEffect, useState } from 'react';
 import axiosInstance from '@services/axios';
 import Search from './Search';
 import { Field } from '@/types/liveTypes';
+import { useIntersect } from '@/hooks/useIntersect';
+import Footer from '@/components/Footer';
+
+const LIMIT = 12;
 
 function LiveList() {
   const [liveList, setLiveList] = useState<LivePreviewInfo[]>([]);
+  const [hasNext, setHasNext] = useState(true);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [field, setField] = useState<Field>('');
+  const ref = useIntersect({
+    onIntersect: (entry, observer) => {
+      observer.unobserve(entry.target);
+      if (hasNext) getLiveList();
+    },
+    options: { threshold: 0.3 },
+  });
 
-  useEffect(() => {
-    axiosInstance.get('v1/broadcasts').then(response => {
+  const getLiveList = () => {
+    if (!hasNext) return;
+    axiosInstance.get('/v1/broadcasts', { params: { field, cursor, limit: LIMIT } }).then(response => {
       if (response.data.success) {
-        setLiveList(response.data.data.broadcasts);
-      }
-    });
-  }, []);
-
-  const handleFilterField = (field: Field) => {
-    axiosInstance.get('/v1/broadcasts', { params: { field: field } }).then(response => {
-      if (response.data.success) {
-        setLiveList(response.data.data.broadcasts);
+        const { broadcasts, nextCursor } = response.data.data;
+        setLiveList(prev => [...prev, ...broadcasts]);
+        setCursor(nextCursor);
+        if (!nextCursor) setHasNext(false);
       }
     });
   };
 
+  useEffect(() => {
+    getLiveList();
+    setHasNext(true);
+    setCursor(null);
+    setLiveList([]);
+    getLiveList();
+  }, [field]);
+
+  const handleFilterField = (field: Field) => {
+    setField(field);
+  };
+
   const handleSearch = (keyword: string) => {
-    axiosInstance.get('v1/broadcasts/search', { params: { keyword: keyword.trim() } }).then(response => {
+    setField('');
+    setCursor(null);
+    axiosInstance.get('/v1/broadcasts/search', { params: { keyword: keyword.trim() } }).then(response => {
       if (response.data.success) {
         setLiveList(response.data.data);
       }
@@ -34,30 +58,35 @@ function LiveList() {
   };
 
   return (
-    <div className="flex flex-col w-full h-full p-10">
+    <div className="flex flex-col w-full h-full p-10 justify-center">
       <div className="h-14 w-full flex justify-between items-center my-5 px-5">
         <FieldFilter onClickFieldButton={handleFilterField} />
         <Search onSearch={handleSearch} />
       </div>
-      <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-x-[clamp(40px,2vw,60px)] gap-y-12 auto-rows-min p-15 w-[95%] max-w-[1920px] align-items-start">
-        {liveList ? (
-          liveList.map(data => {
-            const { broadcastId, broadcastTitle, camperId, profileImage, thumbnail } = data;
-            return (
-              <div key={broadcastId} className="flex justify-center">
-                <LiveCard
-                  liveId={broadcastId}
-                  title={broadcastTitle}
-                  userId={camperId}
-                  profileUrl={profileImage}
-                  thumbnailUrl={thumbnail}
-                />
-              </div>
-            );
-          })
-        ) : (
-          <div>방송 정보가 없습니다.</div>
-        )}
+      <div className="flex flex-col h-full justify-center">
+        <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-x-[clamp(40px,2vw,60px)] gap-y-12 auto-rows-min p-15 w-[95%] max-w-[1920px] align-items-start">
+          {liveList ? (
+            liveList.map(data => {
+              const { broadcastId, broadcastTitle, camperId, profileImage, thumbnail } = data;
+              return (
+                <div key={broadcastId} className="flex justify-center">
+                  <LiveCard
+                    liveId={broadcastId}
+                    title={broadcastTitle}
+                    userId={camperId}
+                    profileUrl={profileImage}
+                    thumbnailUrl={thumbnail}
+                  />
+                </div>
+              );
+            })
+          ) : (
+            <div>방송 정보가 없습니다.</div>
+          )}
+        </div>
+        <div ref={ref} className="h-32">
+          <Footer />
+        </div>
       </div>
     </div>
   );

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -23,7 +23,6 @@ function LiveList() {
   });
 
   const getLiveList = () => {
-    if (!hasNext) return;
     axiosInstance.get('/v1/broadcasts', { params: { field, cursor, limit: LIMIT } }).then(response => {
       if (response.data.success) {
         const { broadcasts, nextCursor } = response.data.data;
@@ -34,15 +33,15 @@ function LiveList() {
     });
   };
 
-  useEffect(() => {
-    setHasNext(true);
-    setCursor(null);
-    setLiveList([]);
-    getLiveList();
-  }, [field]);
-
-  const handleFilterField = (field: Field) => {
-    setField(field);
+  const hanldeFilterField = (field: Field) => {
+    axiosInstance.get('/v1/broadcasts', { params: { field, cursor: null, limit: LIMIT } }).then(response => {
+      if (response.data.success) {
+        const { broadcasts, nextCursor } = response.data.data;
+        setLiveList(broadcasts);
+        setCursor(nextCursor);
+        setHasNext(nextCursor ? true : false);
+      }
+    });
   };
 
   const handleSearch = (keyword: string) => {
@@ -55,10 +54,14 @@ function LiveList() {
     });
   };
 
+  useEffect(() => {
+    getLiveList();
+  }, []);
+
   return (
     <div className="flex flex-col w-full flex-1 p-10 justify-center">
       <div className="h-14 w-full flex justify-between items-center my-5 px-5">
-        <FieldFilter onClickFieldButton={handleFilterField} />
+        <FieldFilter onClickFilterButton={hanldeFilterField} />
         <Search onSearch={handleSearch} />
       </div>
       <div className="flex flex-col w-full h-full items-center">
@@ -82,7 +85,7 @@ function LiveList() {
             <div>방송 정보가 없습니다.</div>
           )}
         </div>
-        <div ref={ref} className="h-32"></div>
+        <div ref={ref} className="h-1"></div>
       </div>
     </div>
   );

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -17,7 +17,7 @@ function LiveList() {
   const ref = useIntersect({
     onIntersect: (entry, observer) => {
       observer.unobserve(entry.target);
-      if (hasNext) getLiveList();
+      if (hasNext && cursor) getLiveList();
     },
     options: { threshold: 0.3 },
   });
@@ -35,7 +35,6 @@ function LiveList() {
   };
 
   useEffect(() => {
-    getLiveList();
     setHasNext(true);
     setCursor(null);
     setLiveList([]);

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -61,7 +61,7 @@ function LiveList() {
         <FieldFilter onClickFieldButton={handleFilterField} />
         <Search onSearch={handleSearch} />
       </div>
-      <div className="flex flex-col h-full justify-center">
+      <div className="flex flex-col w-full h-full items-center">
         <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-x-[clamp(40px,2vw,60px)] gap-y-12 auto-rows-min p-15 w-[95%] max-w-[1920px] align-items-start">
           {liveList ? (
             liveList.map(data => {

--- a/apps/client/src/pages/Home/LiveList.tsx
+++ b/apps/client/src/pages/Home/LiveList.tsx
@@ -6,7 +6,6 @@ import axiosInstance from '@services/axios';
 import Search from './Search';
 import { Field } from '@/types/liveTypes';
 import { useIntersect } from '@/hooks/useIntersect';
-import Footer from '@/components/Footer';
 
 const LIMIT = 12;
 
@@ -58,7 +57,7 @@ function LiveList() {
   };
 
   return (
-    <div className="flex flex-col w-full h-full p-10 justify-center">
+    <div className="flex flex-col w-full flex-1 p-10 justify-center">
       <div className="h-14 w-full flex justify-between items-center my-5 px-5">
         <FieldFilter onClickFieldButton={handleFilterField} />
         <Search onSearch={handleSearch} />
@@ -84,9 +83,7 @@ function LiveList() {
             <div>방송 정보가 없습니다.</div>
           )}
         </div>
-        <div ref={ref} className="h-32">
-          <Footer />
-        </div>
+        <div ref={ref} className="h-32"></div>
       </div>
     </div>
   );

--- a/apps/client/src/pages/Home/index.tsx
+++ b/apps/client/src/pages/Home/index.tsx
@@ -1,11 +1,13 @@
 import LiveList from '@pages/Home/LiveList';
 import Banner from './Banner';
+import Footer from '@components/Footer';
 
 export default function Home() {
   return (
     <div className="flex flex-col justify-center w-full h-full">
       <Banner />
       <LiveList />
+      <Footer />
     </div>
   );
 }

--- a/apps/client/src/pages/Home/index.tsx
+++ b/apps/client/src/pages/Home/index.tsx
@@ -4,9 +4,11 @@ import Footer from '@components/Footer';
 
 export default function Home() {
   return (
-    <div className="flex flex-col justify-center w-full h-full">
-      <Banner />
-      <LiveList />
+    <div className="flex flex-col justify-between w-full min-h-[calc(100vh-74px)]">
+      <div>
+        <Banner />
+        <LiveList />
+      </div>
       <Footer />
     </div>
   );

--- a/apps/client/src/types/homeTypes.ts
+++ b/apps/client/src/types/homeTypes.ts
@@ -1,10 +1,12 @@
+import { Field } from './liveTypes';
+
 export interface LivePreviewInfo {
   broadcastId: string;
   broadcastTitle: string;
   camperId: string;
   profileImage: string;
   thumbnail: string;
-  field: 'WEB' | 'AND' | 'IOS';
+  field: Field;
 }
 
 export interface LivePreviewListInfo {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #349

## ✨ 구현 기능 명세

- 방송 목록 무한 스크롤
- Footer 구현
- useIntersect 커스텀 훅 구현
- 방송 목록 중앙 정렬 해결

## 🎁 PR Point

### 방송 목록 무한 스크롤

> [Intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)는 브라우저 뷰포트(Viewport)와 설정한 요소(Element)의 교차점을 관찰하며, 요소가 뷰포트에 포함되는지 포함되지 않는지, 더 쉽게는 사용자 화면에 지금 보이는 요소인지 아닌지를 구별하는 기능을 제공합니다.

Intersection observer를 이용하여 useIntersect 커스텀 훅 구현했다. 

useIntersect는 div 요소를 참조할 수 있는 ref를 반환하는데, 이 ref로 뷰포트에 포함되는지 안되는지 확인할 div 요소를 참조하게 된다. 이번 구현에서는 방송 목록의 맨 아래에 사용자들의 눈에는 보이지 않는 div를 하나 넣어놓고 여기에 닿으면 cursor 다음 데이터를 갖고 오도록 구현했다.

```typescript
function LiveList() {
  // ...
  const ref = useIntersect({
    onIntersect: (entry, observer) => {
      observer.unobserve(entry.target);
      if (hasNext && cursor) getLiveList();
    },
    options: { threshold: 0.3 },
  });
    
  // ...
  
  return (
  <div className="flex flex-col w-full flex-1 p-10 justify-center">
    <div className="h-14 w-full flex justify-between items-center my-5 px-5">
      <FieldFilter onClickFilterButton={hanldeFilterField} />
      <Search onSearch={handleSearch} />
    </div>
    <div className="flex flex-col w-full h-full items-center">
      <div className="grid grid-cols-1 min-[690px]:grid-cols-2 min-[1040px]:grid-cols-3 min-[1380px]:grid-cols-4 min-[1720px]:grid-cols-5 gap-x-[clamp(40px,2vw,60px)] gap-y-12 auto-rows-min p-15 w-[95%] max-w-[1920px] align-items-start">
        {/* 방송 목록 */ }
      </div>
      <div ref={ref} className="h-1"></div>
    </div>
  </div>
);
}
```

## 😭 어려웠던 점
