### PR TITLE
[Fix] ffmpeg 옵션 수정

### DIFF
--- a/apps/record/src/ffmpeg.ts
+++ b/apps/record/src/ffmpeg.ts
@@ -87,7 +87,7 @@ const thumbnailArgs = (dirPath: string, roomId: string) => {
     '-i',
     'pipe:0', // SDP를 파이프로 전달
     '-vf',
-    'fps=1/10,scale=1280:720', // 10초마다 한 프레임을 캡처하고 해상도 조정
+    'fps=1/15', // 10초마다 한 프레임을 캡처
     '-f',
     'image2', // 이미지 출력 포맷 명시
     '-update',
@@ -111,13 +111,13 @@ const recordArgs = (dirPath: string, roomId: string) => {
     '-c:v',
     'libx264', // 비디오 코덱
     '-preset',
-    'slow',
+    'superfast',
     '-profile:v',
     'high', // H.264 High 프로필
     '-level:v',
     '4.1', // H.264 레벨 설정 (4.1)
     '-crf',
-    '1', // 비디오 품질 설정
+    '23', // 비디오 품질 설정
     '-c:a',
     'libmp3lame', // 오디오 코덱
     '-b:a',


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호

## ✨ 구현 기능 명세
- ffmpeg 옵션 수정
    - preset superfast
    - crf 23
    - 썸네일 해상도 설정 삭제
    - 썸네일 주기 15초로 변경
      
## 🎁 PR Point
- 로컬에서는 cpu 사용량이 현저히 줄어드는것을 확인했습니다.

## 😭 어려웠던 점
