### PR TITLE
[Fix] getUserMedia에서 비디오 옵션 수정

### DIFF
--- a/apps/client/src/hooks/useMedia.ts
+++ b/apps/client/src/hooks/useMedia.ts
@@ -13,7 +13,11 @@ export const useMedia = () => {
   const initializeStream = async () => {
     try {
       const mediaStream = await navigator.mediaDevices.getUserMedia({
-        video: true,
+        video: {
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+          aspectRatio: { ideal: 16 / 9 },
+        },
         audio: true,
       });
 

--- a/apps/media/src/sfu/services/consumer.service.ts
+++ b/apps/media/src/sfu/services/consumer.service.ts
@@ -19,7 +19,7 @@ export class ConsumerService {
           rtpCapabilities,
           paused: false,
           preferredLayers: {
-            spatialLayer: QUALITY_LAYER[QUALITY.MID], // 0,1,2 순으로 480p,720p,1080p. 기본값은 중간인 720p로 시작.
+            spatialLayer: QUALITY_LAYER[QUALITY.HIGH], // 0,1,2 순으로 480p,720p,1080p. 기본값은 중간인 720p로 시작.
             temporalLayer: 2, // fps: 0,1,2순으로 기본 fps의 1/4, 1/2, 1 로 들어감.
           },
         });

--- a/apps/media/src/sfu/services/record.service.ts
+++ b/apps/media/src/sfu/services/record.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as mediasoup from 'mediasoup';
 import { firstValueFrom, lastValueFrom } from 'rxjs';
+import { QUALITY, QUALITY_LAYER } from '../constants/quality-layer.constant';
 
 const STREAM_TYPE = {
   RECORD: 'record',
@@ -33,7 +34,7 @@ export class RecordService {
       rtpCapabilities,
       paused: true,
       preferredLayers: {
-        spatialLayer: 2,
+        spatialLayer: QUALITY_LAYER[QUALITY.HIGH],
         temporalLayer: 2,
       },
     });


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #377

## ✨ 구현 기능 명세

getUserMedia에서 비디오 옵션 수정

## 🎁 PR Point

기본적으로 웹캠은 1920X1080까지 지원이 되지 않기 때문에 `Could not start video source`라는 에러가 발생했다. 그래서 해상도를 1280X720으로 낮춰줬다.

## 😭 어려웠던 점
