### PR TITLE
[Fix] tailwind.config.js 관련 빌드 문제 해결

### DIFF
--- a/apps/client/tailwind.config.js
+++ b/apps/client/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+import * as tailwindAnimate from 'tailwindcss-animate';
 
 export default {
   darkMode: ['class'],
@@ -100,5 +101,5 @@ export default {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [tailwindAnimate],
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #379 

## ✨ 구현 기능 명세

- github action에서 빌드 중 발생하던 문제 해결

## 🎁 PR Point

이전에 올린 테마 변경 PR이 merge된 후 실행된 github action에서 빌드 중 다음과 같은 빌드 에러가 발생

![image](https://github.com/user-attachments/assets/1dd03d7f-eb34-4678-9ab1-bedd87941c4c)

찾아보니 ES module 방식을 사용하고 있는데 플러그인은 `require`으로 모듈을 갖고 와서 그랬던 것 같다. 로컬에서는 빌드 문제가 발생하지 않았는데, github actions는 commonJS와 ES Module에 대해 더 엄격히 보는 것 같다.

**기존의 `tailwind.config.js` 코드**
```javascript
/** @type {import('tailwindcss').Config} */
export default {
  darkMode: ['class'],
  content: ['./src/**/*.{js,jsx,ts,tsx}'],
  theme: {
    extend: {
      // ... 나머지 설정 동일 ...
    },
  },
  plugins: [require('tailwindcss-animate')],
};
```

**변경된 `tailwind.config.js` 코드**
```javascript
/** @type {import('tailwindcss').Config} */
import * as tailwindAnimate from 'tailwindcss-animate';

export default {
  darkMode: ['class'],
  content: ['./src/**/*.{js,jsx,ts,tsx}'],
  theme: {
    extend: {
      // ... 나머지 설정 동일 ...
    },
  },
  plugins: [tailwindAnimate],
};
```

`require` 대신 `import`해오는 방식으로 변경했다.

- 참고 자료: https://stackoverflow.com/questions/79272234/error-in-react-app-vercel-deployment-plugins-requiretailwindcss-animate

## 😭 어려웠던 점
